### PR TITLE
[feature/dummy-data]: Dummy 데이터 로드 및 사용 기능 구현

### DIFF
--- a/CineHive/CineHive/ContentView.swift
+++ b/CineHive/CineHive/ContentView.swift
@@ -9,16 +9,10 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
-        }
-        .padding()
+        TestDummyMovieListView()
     }
 }
 
 #Preview {
-    ContentView()
+    TestDummyMovieListView()
 }

--- a/CineHive/CineHive/Models/Movie.swift
+++ b/CineHive/CineHive/Models/Movie.swift
@@ -1,0 +1,76 @@
+//
+//  Movie.swift
+//  CineHive
+//
+//  Created by 이종민 on 2/16/25.
+//
+
+import Foundation
+
+struct MovieResponse: Codable {
+    let dates: DateRange?
+    let page: Int
+    let results: [Movie]
+    let totalPages: Int
+    let totalResults: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case dates
+        case page
+        case results
+        case totalPages = "total_pages"
+        case totalResults = "total_results"
+    }
+}
+
+// 날짜 범위 (최신 영화 목록에서 제공)
+struct DateRange: Codable {
+    let maximum: String
+    let minimum: String
+}
+
+struct Movie: Codable, Identifiable {
+    let id: Int
+    let title: String
+    let originalTitle: String
+    let originalLanguage: String
+    let overview: String
+    let posterPath: String?
+    let backdropPath: String?
+    let releaseDate: String
+    let genreIds: [Int]
+    let popularity: Double
+    let voteAverage: Double
+    let voteCount: Int
+    let video: Bool
+    let adult: Bool
+    
+    var posterURL: URL? {
+        guard let path = posterPath else { return nil }
+        return URL(string: "https://image.tmdb.org/t/p/w500\(path)")
+    }
+    
+    var backdropURL: URL? {
+        guard let path = backdropPath else { return nil }
+        return URL(string: "https://image.tmdb.org/t/p/w780\(path)")
+    }
+    
+    // API명세서 완료 시, 수정예정
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case originalTitle = "original_title"
+        case originalLanguage = "original_language"
+        case overview
+        case posterPath = "poster_path"
+        case backdropPath = "backdrop_path"
+        case releaseDate = "release_date"
+        case genreIds = "genre_ids"
+        case popularity
+        case voteAverage = "vote_average"
+        case voteCount = "vote_count"
+        case video
+        case adult
+        
+    }
+}

--- a/CineHive/CineHive/Resources/TrendingMoviesDummyData.json
+++ b/CineHive/CineHive/Resources/TrendingMoviesDummyData.json
@@ -1,0 +1,424 @@
+{
+  "page": 1,
+  "results": [
+    {
+      "backdrop_path": "/9nhjGaFLKtddDPtPaX5EmKqsWdH.jpg",
+      "id": 950396,
+      "title": "'더 캐니언' - The Gorge",
+      "original_title": "The Gorge",
+      "overview": "고도의 훈련을 받은 두 요원는 비밀스러운 협곡의 양쪽을 지키는 임무를 받은 후 멀리서 서로와 서서히 친해진다. 도사리고 있던 악이 드러나자, 둘은 협곡 안의 위험으로부터 살아남기 위해 협력해야만 한다.",
+      "poster_path": "/fhPj5pWbCoVoz8sehfaCeIWWFxc.jpg",
+      "media_type": "movie",
+      "adult": false,
+      "original_language": "en",
+      "genre_ids": [
+        28,
+        53,
+        10749,
+        27,
+        878
+      ],
+      "popularity": 331.113,
+      "release_date": "2025-02-13",
+      "video": false,
+      "vote_average": 7.798,
+      "vote_count": 290
+    },
+    {
+      "backdrop_path": "/rOMLLMGgDgGG6XeT3P8sUdUb8nl.jpg",
+      "id": 1126166,
+      "title": "플라이트 리스크",
+      "original_title": "Flight Risk",
+      "overview": "미셸 도커리가 연기하는 부지런한 미국 연방보호관 매들린 해리스는 마피아 조직의 회계사였던 윈스턴(토퍼 그레이스)을 증인 보호 프로그램으로 이송하는 임무를 맡게 된다. 그들은 알래스카의 황량한 설원을 가로지르는 작은 비행기에 탑승하며, 이 비행기의 조종사는 다릴 부스(마크 월버그)다. 그러나 비행 도중, 이들이 탑승한 비행기는 예상치 못한 위험에 직면하게 되고, 매들린은 조종사와 승객들의 숨겨진 의도를 의심하게 된다. 한정된 공간에서 긴장감이 고조되는 가운데, 매들린은 비행기의 조종을 직접 맡아야 하는 상황에 이르게 되는데...",
+      "poster_path": "/4cR3hImKd78dSs652PAkSAyJ5Cx.jpg",
+      "media_type": "movie",
+      "adult": false,
+      "original_language": "en",
+      "genre_ids": [
+        28,
+        53,
+        80
+      ],
+      "popularity": 293.637,
+      "release_date": "2025-01-22",
+      "video": false,
+      "vote_average": 6,
+      "vote_count": 109
+    },
+    {
+      "backdrop_path": "/ywe9S1cOyIhR5yWzK7511NuQ2YX.jpg",
+      "id": 822119,
+      "title": "캡틴 아메리카: 브레이브 뉴 월드",
+      "original_title": "Captain America: Brave New World",
+      "overview": "대통령이 된 새디우스 로스와 재회 후, 국제적인 사건의 중심에 서게 된 샘이 전 세계를 붉게 장악하려는 사악한 음모 뒤에 숨겨진 존재와 이유를 파헤쳐 나가는 액션 블록버스터",
+      "poster_path": "/2MQdtfioyYSqgwkK07PSrBidOBC.jpg",
+      "media_type": "movie",
+      "adult": false,
+      "original_language": "en",
+      "genre_ids": [
+        878,
+        28,
+        53
+      ],
+      "popularity": 2934.792,
+      "release_date": "2025-02-12",
+      "video": false,
+      "vote_average": 6.2,
+      "vote_count": 279
+    },
+    {
+      "backdrop_path": "/hfTyu2VPBqLRPo2DauW8q7bh9bm.jpg",
+      "id": 516729,
+      "title": "패딩턴: 페루에 가다!",
+      "original_title": "Paddington in Peru",
+      "overview": "영국 국민으로 거듭난 ‘패딩턴’에게 어느 날 고향인 페루에서 날아온 의문의 편지 한 통. “루시 숙모님이 사라졌어요!” 지도 한 장만 남긴 채 감쪽같이 사라져 버린 ‘루시’ 숙모를 찾아 떠난 ‘패딩턴’과 브라운 가족은 페루의 정글을 둘러싼 비밀을 찾아 모험을 떠나게 되는데…",
+      "poster_path": "/1rfxGlRaFe8bqKOtebXl2CFel8F.jpg",
+      "media_type": "movie",
+      "adult": false,
+      "original_language": "en",
+      "genre_ids": [
+        10751,
+        12,
+        35
+      ],
+      "popularity": 249.924,
+      "release_date": "2024-11-08",
+      "video": false,
+      "vote_average": 7.1,
+      "vote_count": 82
+    },
+    {
+      "backdrop_path": "/uJK0jjJ8QDOQw5lcNBwu059ht4D.jpg",
+      "id": 1294203,
+      "title": "나의 잘못: 런던",
+      "original_title": "My Fault: London",
+      "overview": "영국의 부유한 사업가 윌리엄과 최근 사랑에 빠진 엄마를 따라 미국에서 영국으로 거처를 옮긴 18세 노아는 윌리엄의 불량한 아들 닉을 만나게 되고 둘은 서로에게 거부할 수 없는 매력을 느낀다. 여름 내내 노아는 새로운 생활에 적응하며 처음으로 사랑에 빠지지만 과거의 괴로운 기억이 노아의 발목을 잡는다.",
+      "poster_path": "/h7H6Kd9kX1dvN8FZjUy6FcNdXxQ.jpg",
+      "media_type": "movie",
+      "adult": false,
+      "original_language": "en",
+      "genre_ids": [
+        10749,
+        18
+      ],
+      "popularity": 499.279,
+      "release_date": "2025-02-12",
+      "video": false,
+      "vote_average": 7.517,
+      "vote_count": 86
+    },
+    {
+      "backdrop_path": "/zwSDvbnN51JqU1ULzPnEc22DkqV.jpg",
+      "id": 1272149,
+      "title": "브리짓 존스의 일기: 매드 어바웃 더 보이",
+      "original_title": "Bridget Jones: Mad About the Boy",
+      "overview": "50대가 된 브리짓은 수단에서 인도주의적 임무를 수행하던 마크(콜린 퍼스)가 사망한 후 미망인이 된다. 어린 두 자녀를 혼자 키우는 브리짓은 혼란스러운 감정 상태에 놓이지만, 친구들과 옛 연인(휴 그랜트)의 도움으로 다시 안정을 찾아가는데...",
+      "poster_path": "/7DjUCXDOBZQHgCTAupfCQFSOLzl.jpg",
+      "media_type": "movie",
+      "adult": false,
+      "original_language": "en",
+      "genre_ids": [
+        35,
+        18,
+        10749
+      ],
+      "popularity": 424.084,
+      "release_date": "2025-02-12",
+      "video": false,
+      "vote_average": 7.2,
+      "vote_count": 43
+    },
+    {
+      "backdrop_path": "/1YL8ksfwm3p2Tgt1yaNVYYOvOKC.jpg",
+      "id": 1203329,
+      "title": "위쳐: 세이렌의 바다",
+      "original_title": "The Witcher: Sirens of the Deep",
+      "overview": "심해에서 정체불명의 바다 생물이 뱃사람들을 공격하는 사건이 벌어진다. 이제 육지와 바다 사이의 전쟁을 막을 수 있는 이는 단 한 사람, 최고의 위쳐인 리비아의 게롤트뿐이다.",
+      "poster_path": "/dr1531wNFRXamAQlcTe74JpNKLU.jpg",
+      "media_type": "movie",
+      "adult": false,
+      "original_language": "en",
+      "genre_ids": [
+        16,
+        14,
+        28
+      ],
+      "popularity": 310.552,
+      "release_date": "2025-02-10",
+      "video": false,
+      "vote_average": 7.3,
+      "vote_count": 63
+    },
+    {
+      "backdrop_path": "/h7r6LZ32dgLwtwSW3CxoWIYD9pr.jpg",
+      "id": 426063,
+      "title": "노스페라투",
+      "original_title": "Nosferatu",
+      "overview": "오랜 시간 통제할 수 없는 강력한 힘에 이끌려 악몽과 괴로움에 시달려 온 엘렌. 남편 토마스가 거액의 부동산 계약을 위해 머나먼 올록성으로 떠난 후부터 엘렌은 불안 증세가 심해지고 알 수 없는 말을 되뇌인다. 기이한 현상들이 일어나며 마을로 점점 짙게 번져오는 그림자. 영원한 어둠 속에서 깨어난 올록 백작이 찾아오는데…",
+      "poster_path": "/xeiARSpxGdVCw5KkCDgj31MO45o.jpg",
+      "media_type": "movie",
+      "adult": false,
+      "original_language": "en",
+      "genre_ids": [
+        27,
+        14
+      ],
+      "popularity": 658.673,
+      "release_date": "2024-12-25",
+      "video": false,
+      "vote_average": 6.7,
+      "vote_count": 2068
+    },
+    {
+      "backdrop_path": "/l2QSVFR5aLcW1Vl4cGKrQkEp6fY.jpg",
+      "id": 1201012,
+      "title": "둠 담",
+      "original_title": "धूम धाम",
+      "overview": "도무지 어울릴 것 같지 않은 커플의 결혼식 날 밤. 예상치 못한 사건이 발생하면서 두 사람은 깡패들과 경찰들을 피해 '찰리'라는 미스터리한 인물을 찾아야 하는 혼돈의 추격전에 휘말린다.",
+      "poster_path": "/1K1PqJxOPHtsEPQLP243EJPsOvu.jpg",
+      "media_type": "movie",
+      "adult": false,
+      "original_language": "hi",
+      "genre_ids": [
+        35,
+        10749,
+        28
+      ],
+      "popularity": 47.869,
+      "release_date": "2025-02-13",
+      "video": false,
+      "vote_average": 7.3,
+      "vote_count": 3
+    },
+    {
+      "backdrop_path": "/s1ge9SG2zfJdMeZ69VMEbxeKuAE.jpg",
+      "id": 1252377,
+      "title": "달콤한 이곳",
+      "original_title": "La Dolce Villa",
+      "overview": "딸이 토스카나의 낡은 저택을 사들이겠다고 하자, 이를 말리기 위해 서둘러 이탈리아로 향한 에릭. 그러나 그곳에서 그는 아름다운 풍경과 로맨스, 그리고 새로운 삶의 의미를 만나게 된다.",
+      "poster_path": "/rfLLUNUxsDBGmw16HuqrnKzovY6.jpg",
+      "media_type": "movie",
+      "adult": false,
+      "original_language": "en",
+      "genre_ids": [
+        10749,
+        35
+      ],
+      "popularity": 98.207,
+      "release_date": "2025-02-12",
+      "video": false,
+      "vote_average": 6.5,
+      "vote_count": 29
+    },
+    {
+      "backdrop_path": "/8btfz81bOJ2lC7cujYBTw03wzg3.jpg",
+      "id": 980477,
+      "title": "나타지마동요해",
+      "original_title": "哪吒之魔童闹海",
+      "overview": "\"그가 돌아왔다, 더욱 강력해진 영웅의 전설\"  천계의 시련 이후, 혼은 유지했으나 육신이 소멸 위기에 처한 나타와 오병. 태을진인은 일곱 빛깔의 보련으로 그들의 육신을 재건하려 하지만, 과정은 순탄치 않다. 신공표는 심해에 갇혀 있던 사룡왕을 해방시키고, 동해의 용왕 오광은 \"내가 전쟁에 나서면, 천당관은 남김없이 파괴될 것이다\"라고 선언한다. 나타는 천당관을 지키기 위해 사해의 용왕들과 맞서 싸우게 되는데...",
+      "poster_path": "/bTMf8M7rZ21fChGdtsZtJj4Dfqh.jpg",
+      "media_type": "movie",
+      "adult": false,
+      "original_language": "zh",
+      "genre_ids": [
+        16,
+        14,
+        12
+      ],
+      "popularity": 365.178,
+      "release_date": "2025-01-29",
+      "video": false,
+      "vote_average": 8.2,
+      "vote_count": 68
+    },
+    {
+      "backdrop_path": "/wP0NGOGf2PG4lHXHWEqFW0kBOye.jpg",
+      "id": 799766,
+      "title": "베터 맨",
+      "original_title": "Better Man",
+      "overview": "",
+      "poster_path": "/fbGCmMp0HlYnAPv28GOENPShezM.jpg",
+      "media_type": "movie",
+      "adult": false,
+      "original_language": "en",
+      "genre_ids": [
+        10402,
+        18
+      ],
+      "popularity": 375.814,
+      "release_date": "2024-12-14",
+      "video": false,
+      "vote_average": 7.5,
+      "vote_count": 169
+    },
+    {
+      "backdrop_path": "/zOpe0eHsq0A2NvNyBbtT6sj53qV.jpg",
+      "id": 939243,
+      "title": "수퍼 소닉 3",
+      "original_title": "Sonic the Hedgehog 3",
+      "overview": "너클즈, 테일즈와 함께 평화로운 일상을 보내던 초특급 히어로 소닉. 연구 시설에 50년간 잠들어 있던 사상 최강의 비밀 병기 \"섀도우\"가 탈주하자, 세계 수호 통합 부대(약칭 세.수.통)에 의해 극비 소집된다. 소중한 것을 잃은 분노와 복수심에 불타는 섀도우는 소닉의 초고속 스피드와 너클즈의 최강 펀치를 단 단숨에 제압해버린다. 세상을 지배하려는 닥터 로보트닉과 그의 할아버지 제럴드 박사는 섀도우의 엄청난 힘 카오스 에너지를 이용해 인류를 정복하려고 하는데…",
+      "poster_path": "/5ZoI48Puf5i5FwI6HOpunDuJOw0.jpg",
+      "media_type": "movie",
+      "adult": false,
+      "original_language": "en",
+      "genre_ids": [
+        28,
+        878,
+        35,
+        10751
+      ],
+      "popularity": 2997.868,
+      "release_date": "2024-12-19",
+      "video": false,
+      "vote_average": 7.764,
+      "vote_count": 1756
+    },
+    {
+      "backdrop_path": "/wVLPPX2DXQmfkzDe6MOsJJfbKEX.jpg",
+      "id": 1393069,
+      "title": "세상에서 가장 아름다운 여자",
+      "original_title": "The Most Beautiful Girl in the World",
+      "overview": "아버지의 마지막 소원은 아들이 세상에서 가장 아름다운 여자와 결혼하는 것. 바람둥이로 살던 아들은 아버지의 유산을 상속받기 위해 연애 프로그램을 직접 연출하기로 한다.",
+      "poster_path": "/2o4nRutaidL9nfD5GsLWot5WCBx.jpg",
+      "media_type": "movie",
+      "adult": false,
+      "original_language": "id",
+      "genre_ids": [
+        10749,
+        35
+      ],
+      "popularity": 61.579,
+      "release_date": "2025-02-13",
+      "video": false,
+      "vote_average": 7,
+      "vote_count": 3
+    },
+    {
+      "backdrop_path": "/lBcXozUeABairkTavz3X3ZAtOL0.jpg",
+      "id": 959604,
+      "title": "비팅 하츠",
+      "original_title": "L'Amour ouf",
+      "overview": "",
+      "poster_path": "/6akNNv4KyrguZUiG4uemfV6toVq.jpg",
+      "media_type": "movie",
+      "adult": false,
+      "original_language": "fr",
+      "genre_ids": [
+        10749,
+        80,
+        18
+      ],
+      "popularity": 119.776,
+      "release_date": "2024-10-16",
+      "video": false,
+      "vote_average": 7.4,
+      "vote_count": 556
+    },
+    {
+      "backdrop_path": "/eGK2JJO1ZeoabWThHmC9IjUTmfP.jpg",
+      "id": 615453,
+      "title": "나타지마동강세",
+      "original_title": "哪吒之魔童降世",
+      "overview": "태을진인의 실수로 영주(선) 대신 마환(악)은 이정의 아들 나타로 환생한다. 3년 후, 천겁을 맞고 사라져야 할 운명을 타고난 나타는 마을을 혼란에 빠트려 사람들의 미움을 사게 된다. 세상에 파멸을 가져올 운명을 짊어진 나타의 마지막은 과연…",
+      "poster_path": "/rMLVDNxpv1hLjim7Shm5uKUPw83.jpg",
+      "media_type": "movie",
+      "adult": false,
+      "original_language": "zh",
+      "genre_ids": [
+        16,
+        14,
+        12
+      ],
+      "popularity": 160.082,
+      "release_date": "2019-07-26",
+      "video": false,
+      "vote_average": 7.9,
+      "vote_count": 437
+    },
+    {
+      "backdrop_path": "/jTOeWjamUKGxWVUO1TMZXqQUarw.jpg",
+      "id": 402431,
+      "title": "위키드",
+      "original_title": "Wicked",
+      "overview": "자신의 진정한 힘을 아직 발견하지 못한 엘파바와 자신의 진정한 본성을 발견하지 못한 글린다, 전혀 다른 두 인물이 우정을 쌓아가며 맞닥뜨리는 예상치 못한 위기와 모험을 그린 이야기",
+      "poster_path": "/mHozMgx7w29qC9gLzUQDQEP7AEM.jpg",
+      "media_type": "movie",
+      "adult": false,
+      "original_language": "en",
+      "genre_ids": [
+        18,
+        10749,
+        14
+      ],
+      "popularity": 339.083,
+      "release_date": "2024-11-20",
+      "video": false,
+      "vote_average": 6.9,
+      "vote_count": 1729
+    },
+    {
+      "backdrop_path": "/aMbKYfaexixvsBZKc5whYO7yibR.jpg",
+      "id": 1082195,
+      "title": "디 오더",
+      "original_title": "The Order",
+      "overview": "1983년, 베테랑 FBI 요원 테리 허스크는 아이다호주 코들레인으로 전근 와서 태평양 북서부에서 발생하는 일련의 은행 강도와 장갑차 탈취 사건들을 조사하게 된다. 지역 부보안관 제이미 보웬과 함께 수사하면서, 이러한 범죄들이 디 오더라는 백인 우월주의 단체와 관련이 있음을 알게 된다. 이 단체는 리더 밥 매튜스의 지휘 아래, 정부 전복과 인종 전쟁을 목표로 하고 있다. 허스크와 보웬은 그들의 계획을 저지하기 위해 고군분투하며, 개인적인 희생과 도덕적 딜레마에 직면하게 되는데...",
+      "poster_path": "/r3BPhDb45sy87kNV41Q1TwCL6BS.jpg",
+      "media_type": "movie",
+      "adult": false,
+      "original_language": "en",
+      "genre_ids": [
+        80,
+        18,
+        53
+      ],
+      "popularity": 193.705,
+      "release_date": "2024-12-05",
+      "video": false,
+      "vote_average": 6.7,
+      "vote_count": 327
+    },
+    {
+      "backdrop_path": "/bFPqSvR2EmWQ9AlzWkC801XpoAZ.jpg",
+      "id": 933260,
+      "title": "서브스턴스",
+      "original_title": "The Substance",
+      "overview": "한때 아카데미상을 수상하고 명예의 거리까지 입성한 대스타였지만 지금은 TV 에어로빅 쇼 진행자로 전락한 엘리자베스. 50살이 되던 날, 프로듀서에게서 어리고 섹시하지 않다는 이유로 해고를 당한다. 돌아가던 길에 차 사고로 병원에 실려간 엘리자베스는 매력적인 남성 간호사로부터 서브스턴스라는 약물을 권유받는다. 한 번의 주사로 젊고 아름답고 완벽한 수가 탄생하는데...",
+      "poster_path": "/5TPPefBI1OzWnSQfBkOrv1OFGq5.jpg",
+      "media_type": "movie",
+      "adult": false,
+      "original_language": "en",
+      "genre_ids": [
+        27,
+        878
+      ],
+      "popularity": 573.71,
+      "release_date": "2024-09-07",
+      "video": false,
+      "vote_average": 7.1,
+      "vote_count": 3821
+    },
+    {
+      "backdrop_path": "/e8npsTfpBZa8T0TQqyZSwD9RNu2.jpg",
+      "id": 1214481,
+      "title": "러브 포에버",
+      "original_title": "Kärlek fårever",
+      "overview": "아름다운 고틀란드섬에서 결혼식을 올리기로 한 스톡홀름 커플. 그런데 가족들이 고집한 전통 때문에 일생일대의 중요한 날이 순식간에 대참사의 날로 기억될 판이다.",
+      "poster_path": "/yZegcKhavAQ7TBhLu2KPZKudexv.jpg",
+      "media_type": "movie",
+      "adult": false,
+      "original_language": "sv",
+      "genre_ids": [
+        10749,
+        35,
+        18
+      ],
+      "popularity": 53.948,
+      "release_date": "2025-02-13",
+      "video": false,
+      "vote_average": 5,
+      "vote_count": 2
+    }
+  ],
+  "total_pages": 500,
+  "total_results": 10000
+}

--- a/CineHive/CineHive/ViewModels/DummyViewModel.swift
+++ b/CineHive/CineHive/ViewModels/DummyViewModel.swift
@@ -1,0 +1,29 @@
+//
+//  DummyViewModel.swift
+//  CineHive
+//
+//  Created by 이종민 on 2/16/25.
+//
+
+import Foundation
+
+class DummyViewModel: ObservableObject {
+    @Published var movies: [Movie] = []
+    
+    /// 일간 트렌드 영화 로드하는 함수
+    func loadTrendingMovies() {
+        guard let url = Bundle.main.url(forResource: "TrendingMoviesDummyData", withExtension: "json") else {
+            print("Failed to locate TrendingMoviesDummyData.json")
+            return
+        }
+        
+        do {
+            let data = try Data(contentsOf: url)
+            let movieResponse = try JSONDecoder().decode(MovieResponse.self, from: data)
+            self.movies = movieResponse.results
+            print("Trending movies loaded successfully.")
+        } catch {
+            print("Failed to decode TrendingMoviesDummyData.json: \(error)")
+        }
+    }
+}

--- a/CineHive/CineHive/Views/TestDummyMovieListView.swift
+++ b/CineHive/CineHive/Views/TestDummyMovieListView.swift
@@ -1,0 +1,63 @@
+//
+//  TestDummyMovieListView.swift
+//  CineHive
+//
+//  Created by 이종민 on 2/16/25.
+//
+
+import SwiftUI
+
+struct TestDummyMovieListView: View {
+    @StateObject private var viewModel = DummyViewModel()
+    
+    var body: some View {
+        NavigationView {
+            List(viewModel.movies) { movie in
+                HStack(alignment: .top, spacing: 16) {
+                    // 영화 포스터 이미지
+                    AsyncImage(url: movie.posterURL) { image in
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(width: 100, height: 150)
+                            .clipped()
+                            .cornerRadius(8)
+                    } placeholder: {
+                        Rectangle()
+                            .fill(Color.gray.opacity(0.3))
+                            .frame(width: 100, height: 150)
+                            .overlay(
+                                ProgressView() // 로딩 인디케이터
+                            )
+                            .cornerRadius(8)
+                    }
+                    
+                    // 영화 정보
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(movie.title)
+                            .font(.headline)
+                            .lineLimit(2)
+                        Text(movie.overview)
+                            .font(.subheadline)
+                            .lineLimit(3)
+                            .foregroundColor(.secondary)
+                        Text("Release Date: \(movie.releaseDate)")
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                    }
+                }
+                .padding(.vertical, 8)
+            }
+            .navigationTitle("Trending Movies")
+            .onAppear {
+                if viewModel.movies.isEmpty {
+                    viewModel.loadTrendingMovies()
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    TestDummyMovieListView()
+}


### PR DESCRIPTION
## 작업한 내용

- Movie 모델 정의
- 테스트용 Dummy 데이터를 불러오는 로직 추가
- DummyViewModel에 Dummy 데이터 관리 로직 구현
- /Resources에 TrendingMovieList Dummy 데이터 저장
- TestDummyMovieListView Dummy 데이터 활용 UI 구성 테스트

## PR Porint

- 서버 코드 분할 작업으로 인한 임시 Dummy 데이터 사용 목적

## UI 테스트 화면

- TestDummyMovieListView
<img src="https://github.com/user-attachments/assets/45de251f-aa5c-4b47-9fa9-ec33764a17f6" alt="Simulator Screenshot" width="200">
<img src="https://github.com/user-attachments/assets/a56895c4-46f1-4757-8140-9c01441eaa87" alt="Simulator Screenshot" width="200">


