### PR TITLE
[feature/home-ui]: 메인 화면 및 추천 영화 배너 구성 및 개선 

### DIFF
--- a/CineHive/CineHive/Models/Banner.swift
+++ b/CineHive/CineHive/Models/Banner.swift
@@ -1,0 +1,15 @@
+//
+//  Banner.swift
+//  CineHive
+//
+//  Created by 이종민 on 2/19/25.
+//
+
+import Foundation
+
+struct BannerItem: Identifiable {
+    let id = UUID()
+    let imageURL: URL?
+    let title: String
+    let subtitle: String
+}

--- a/CineHive/CineHive/Models/Movie.swift
+++ b/CineHive/CineHive/Models/Movie.swift
@@ -74,3 +74,5 @@ struct Movie: Codable, Identifiable {
         
     }
 }
+
+

--- a/CineHive/CineHive/Models/MovieCategory.swift
+++ b/CineHive/CineHive/Models/MovieCategory.swift
@@ -1,0 +1,38 @@
+//
+//  MovieCategory.swift
+//  CineHive
+//
+//  Created by 이종민 on 2/18/25.
+//
+
+import Foundation
+
+enum MovieListType {
+    case nowPlaying
+    case netflixMovies
+    case disneyMovies
+    case appleTVMovies
+    case isLoading
+    case popular
+    case topRated
+    case upcoming
+    case etc
+    // 추가 영화 타입이 있을 경우 여기에 작성
+}
+
+struct MovieCategory: Identifiable {
+    let id = UUID()
+    let title: String
+    let type: MovieListType
+    
+    // 영화리스트 카테고리
+    static let categories: [MovieCategory] = [
+        MovieCategory(title: "Netflix Top 10 영화", type: .netflixMovies),
+        MovieCategory(title: "Disney+ Top 10 영화", type: .disneyMovies),
+        MovieCategory(title: "Apple TV+ Top 10 영화", type: .appleTVMovies),
+        MovieCategory(title: "현재 상영 영화", type: .nowPlaying),
+        MovieCategory(title: "인기 영화", type: .popular),
+        MovieCategory(title: "최고평점 영화", type: .topRated),
+        MovieCategory(title: "개봉예정작", type: .upcoming)
+    ]
+}

--- a/CineHive/CineHive/Views/HomeView.swift
+++ b/CineHive/CineHive/Views/HomeView.swift
@@ -1,0 +1,40 @@
+//
+//  HomeView.swift
+//  CineHive
+//
+//  Created by 이종민 on 2/18/25.
+//
+
+import SwiftUI
+
+struct HomeView: View {
+    @StateObject private var viewModel = DummyViewModel()
+    
+    var body: some View {
+        ScrollView{
+            VStack {
+                ForEach(MovieCategory.categories) { category in
+                    VStack(alignment: .leading) {
+                        Text(category.title)
+                            .font(.title2)
+                            .bold()
+                        HorizontalMovieListView(movies: viewModel.movies, movieType: category.type, viewModel: viewModel)
+                    }
+                }
+                .padding(.leading, 15)
+                .padding(.top, 30)
+                
+                .navigationTitle("CineHive")
+                .onAppear {
+                    if viewModel.movies.isEmpty {
+                        viewModel.loadTrendingMovies()
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    HomeView()
+}

--- a/CineHive/CineHive/Views/HomeView.swift
+++ b/CineHive/CineHive/Views/HomeView.swift
@@ -13,6 +13,50 @@ struct HomeView: View {
     var body: some View {
         ScrollView{
             VStack {
+                // 오늘의 추천 영화 (배너)
+                ZStack(alignment: .bottomLeading) {
+                    // 배너 이미지 (샘플 URL 사용)
+                    AsyncImage(
+                        url: URL(string: "https://image.tmdb.org/t/p/w500/9nhjGaFLKtddDPtPaX5EmKqsWdH.jpg")
+                    ) { image in
+                        image
+                            .resizable()
+                            .scaledToFill()
+                    } placeholder: {
+                        Rectangle()
+                            .fill(Color.gray.opacity(0.3))
+                            .overlay(
+                                ProgressView()
+                            )
+                    }
+                    .frame(height: 220)
+                    .clipped()
+                    
+                    // 아래쪽 그라디언트 오버레이 (텍스트 가독성 향상)
+                    LinearGradient(
+                        gradient: Gradient(colors: [Color.clear, Color.black.opacity(0.7)]),
+                        startPoint: .center,
+                        endPoint: .bottom
+                    )
+                    .frame(height: 100)
+                    .allowsHitTesting(false)
+                    
+                    // 추천 영화 텍스트
+                    VStack(alignment: .leading, spacing: 5) {
+                        Text("오늘의 추천 영화")
+                            .font(.title3)
+                            .bold()
+                            .foregroundColor(.white)
+                        
+                        Text("인셉션: 꿈 속의 꿈")
+                            .font(.headline)
+                            .foregroundColor(.white)
+                            .padding(.top, 2)
+                    }
+                    .padding(.leading, 16)
+                    .padding(.bottom, 12)
+                }
+                
                 ForEach(MovieCategory.categories) { category in
                     VStack(alignment: .leading) {
                         Text(category.title)
@@ -34,6 +78,7 @@ struct HomeView: View {
         }
     }
 }
+
 
 #Preview {
     HomeView()

--- a/CineHive/CineHive/Views/HomeView.swift
+++ b/CineHive/CineHive/Views/HomeView.swift
@@ -13,49 +13,11 @@ struct HomeView: View {
     var body: some View {
         ScrollView{
             VStack {
-                // 오늘의 추천 영화 (배너)
-                ZStack(alignment: .bottomLeading) {
-                    // 배너 이미지 (샘플 URL 사용)
-                    AsyncImage(
-                        url: URL(string: "https://image.tmdb.org/t/p/w500/9nhjGaFLKtddDPtPaX5EmKqsWdH.jpg")
-                    ) { image in
-                        image
-                            .resizable()
-                            .scaledToFill()
-                    } placeholder: {
-                        Rectangle()
-                            .fill(Color.gray.opacity(0.3))
-                            .overlay(
-                                ProgressView()
-                            )
-                    }
-                    .frame(height: 220)
-                    .clipped()
-                    
-                    // 아래쪽 그라디언트 오버레이 (텍스트 가독성 향상)
-                    LinearGradient(
-                        gradient: Gradient(colors: [Color.clear, Color.black.opacity(0.7)]),
-                        startPoint: .center,
-                        endPoint: .bottom
-                    )
-                    .frame(height: 100)
-                    .allowsHitTesting(false)
-                    
-                    // 추천 영화 텍스트
-                    VStack(alignment: .leading, spacing: 5) {
-                        Text("오늘의 추천 영화")
-                            .font(.title3)
-                            .bold()
-                            .foregroundColor(.white)
-                        
-                        Text("인셉션: 꿈 속의 꿈")
-                            .font(.headline)
-                            .foregroundColor(.white)
-                            .padding(.top, 2)
-                    }
-                    .padding(.leading, 16)
-                    .padding(.bottom, 12)
-                }
+                RecommendedMovieBanner(
+                    imageURL: URL(string: "https://image.tmdb.org/t/p/w500/9nhjGaFLKtddDPtPaX5EmKqsWdH.jpg"),
+                    title: "오늘의 추천 영화",
+                    subtitle: "인셉션: 꿈 속의 꿈"
+                )
                 
                 ForEach(MovieCategory.categories) { category in
                     VStack(alignment: .leading) {

--- a/CineHive/CineHive/Views/HomeView.swift
+++ b/CineHive/CineHive/Views/HomeView.swift
@@ -10,14 +10,24 @@ import SwiftUI
 struct HomeView: View {
     @StateObject private var viewModel = DummyViewModel()
     
+    // 샘플 배너 (테스트용!!)
+    private let bannerItems: [BannerItem] = [
+            BannerItem(
+                imageURL: URL(string: "https://image.tmdb.org/t/p/w500/9nhjGaFLKtddDPtPaX5EmKqsWdH.jpg"),
+                title: "오늘의 추천 영화",
+                subtitle: "인셉션: 꿈 속의 꿈"
+            ),
+            BannerItem(
+                imageURL: URL(string: "https://image.tmdb.org/t/p/w500/8s4h9friP6Ci3adRGahHARVd76E.jpg"),
+                title: "오늘의 추천 영화",
+                subtitle: "인터스텔라: 우주 속의 꿈"
+            )
+        ]
+    
     var body: some View {
         ScrollView{
             VStack {
-                RecommendedMovieBanner(
-                    imageURL: URL(string: "https://image.tmdb.org/t/p/w500/9nhjGaFLKtddDPtPaX5EmKqsWdH.jpg"),
-                    title: "오늘의 추천 영화",
-                    subtitle: "인셉션: 꿈 속의 꿈"
-                )
+                RecommendedMovieBanner(items: bannerItems)
                 
                 ForEach(MovieCategory.categories) { category in
                     VStack(alignment: .leading) {

--- a/CineHive/CineHive/Views/HorizontalMovieListView.swift
+++ b/CineHive/CineHive/Views/HorizontalMovieListView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct HorizontalMovieListView: View {
     let movies: [Movie]
     let movieType: MovieListType
-    @ObservedObject var viewModel: DummyViewModel
+    @State var viewModel: DummyViewModel
     
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {

--- a/CineHive/CineHive/Views/HorizontalMovieListView.swift
+++ b/CineHive/CineHive/Views/HorizontalMovieListView.swift
@@ -1,0 +1,47 @@
+//
+//  HorizontalMovieListView.swift
+//  CineHive
+//
+//  Created by 이종민 on 2/18/25.
+//
+
+import SwiftUI
+
+struct HorizontalMovieListView: View {
+    let movies: [Movie]
+    let movieType: MovieListType
+    @ObservedObject var viewModel: DummyViewModel
+    
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            LazyHStack(spacing: 15) {
+                ForEach(movies, id: \.id) { movie in
+                    NavigationLink(destination: {
+                        //DetailView로 이동
+                    }, label: {
+                        VStack {
+                            if let posterURL = movie.posterURL {
+                                AsyncImage(url: posterURL) { image in
+                                    image
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                } placeholder: {
+                                    Rectangle()
+                                        .fill(Color.gray.opacity(0.3))
+                                        .frame(width: 100, height: 150)
+                                        .overlay(
+                                            ProgressView() // 로딩 인디케이터
+                                        )
+                                        .cornerRadius(8)
+                                }
+                                .cornerRadius(8)
+                                .frame(width: 100, height: 150)
+                            }
+                        }
+                    })
+                }
+            }
+        }
+    }
+}
+

--- a/CineHive/CineHive/Views/MainTabView.swift
+++ b/CineHive/CineHive/Views/MainTabView.swift
@@ -1,0 +1,51 @@
+//
+//  MainTabView.swift
+//  CineHive
+//
+//  Created by 이종민 on 2/18/25.
+//
+
+import SwiftUI
+
+struct MainTabView: View {
+    var body: some View {
+        TabView {
+            NavigationStack {
+                //MovieListView
+                
+            }
+            .tabItem {
+                Label("홈", systemImage: "house")
+            }
+            .refreshable { }
+            
+            NavigationStack {
+                Text("검색 뷰")
+            }
+            .tabItem {
+                Label("검색", systemImage: "magnifyingglass")
+            }
+            .refreshable { }
+            
+            NavigationStack {
+                Text("게시판 뷰")
+            }
+            .tabItem {
+                Label("게시판", systemImage: "quote.bubble")
+            }
+            .refreshable { }
+            
+            NavigationStack {
+                Text("프로필 뷰")
+            }
+            .tabItem {
+                Label("프로필", systemImage: "person")
+            }
+            .refreshable { }
+        }
+    }
+}
+
+#Preview {
+    MainTabView()
+}

--- a/CineHive/CineHive/Views/MainTabView.swift
+++ b/CineHive/CineHive/Views/MainTabView.swift
@@ -11,8 +11,7 @@ struct MainTabView: View {
     var body: some View {
         TabView {
             NavigationStack {
-                //MovieListView
-                
+                HomeView()
             }
             .tabItem {
                 Label("홈", systemImage: "house")

--- a/CineHive/CineHive/Views/RecommendedMovieBannerView.swift
+++ b/CineHive/CineHive/Views/RecommendedMovieBannerView.swift
@@ -8,48 +8,69 @@
 import SwiftUI
 
 struct RecommendedMovieBanner: View {
-    let imageURL: URL?
-    let title: String
-    let subtitle: String
+    /// 여러 배너 아이템을 한 번에 받아와서 TabView로 순환
+    let items: [BannerItem]
     
     var body: some View {
-        ZStack(alignment: .bottomLeading) {
-            // 배너 이미지
-            AsyncImage(url: imageURL) { image in
-                image
-                    .resizable()
-                    .scaledToFill()
-            } placeholder: {
-                Rectangle()
-                    .fill(Color.gray.opacity(0.3))
-                    .overlay(ProgressView())
+        TabView {
+            ForEach(items) { item in
+                ZStack(alignment: .bottomLeading) {
+                    // 배너 이미지
+                    AsyncImage(url: item.imageURL) { image in
+                        image
+                            .resizable()
+                            .scaledToFill()
+                    } placeholder: {
+                        Rectangle()
+                            .fill(Color.gray.opacity(0.3))
+                            .overlay(ProgressView())
+                    }
+                    .frame(height: 220)
+                    .clipped()
+                    
+                    // 아래쪽 그라디언트 오버레이 (텍스트 가독성 향상)
+                    LinearGradient(
+                        gradient: Gradient(colors: [Color.clear, Color.black.opacity(0.7)]),
+                        startPoint: .center,
+                        endPoint: .bottom
+                    )
+                    .frame(height: 100)
+                    .allowsHitTesting(false)
+                    
+                    // 텍스트
+                    VStack(alignment: .leading, spacing: 5) {
+                        Text(item.title)
+                            .font(.title3)
+                            .bold()
+                            .foregroundColor(.white)
+                        
+                        Text(item.subtitle)
+                            .font(.headline)
+                            .foregroundColor(.white)
+                            .padding(.top, 2)
+                    }
+                    .padding(.leading, 16)
+                    .padding(.bottom, 12)
+                }
             }
-            .frame(height: 220)
-            .clipped()
-            
-            // 그라디언트 오버레이
-            LinearGradient(
-                gradient: Gradient(colors: [Color.clear, Color.black.opacity(0.7)]),
-                startPoint: .center,
-                endPoint: .bottom
-            )
-            .frame(height: 100)
-            .allowsHitTesting(false)
-            
-            // 텍스트
-            VStack(alignment: .leading, spacing: 5) {
-                Text(title)
-                    .font(.title3)
-                    .bold()
-                    .foregroundColor(.white)
-                
-                Text(subtitle)
-                    .font(.headline)
-                    .foregroundColor(.white)
-                    .padding(.top, 2)
-            }
-            .padding(.leading, 16)
-            .padding(.bottom, 12)
         }
+        .tabViewStyle(PageTabViewStyle(indexDisplayMode: .automatic)) // 페이지 인디케이터
+        .frame(height: 220)
     }
 }
+
+#Preview {
+    RecommendedMovieBanner(items: [
+        BannerItem(
+            imageURL: URL(string: "https://image.tmdb.org/t/p/w500/9nhjGaFLKtddDPtPaX5EmKqsWdH.jpg"),
+            title: "오늘의 추천 영화",
+            subtitle: "인셉션: 꿈 속의 꿈"
+        ),
+        BannerItem(
+            imageURL: URL(string: "https://image.tmdb.org/t/p/w500/8s4h9friP6Ci3adRGahHARVd76E.jpg"),
+            title: "오늘의 추천 영화",
+            subtitle: "인터스텔라: 우주 속의 꿈"
+        )
+    ])
+}
+

--- a/CineHive/CineHive/Views/RecommendedMovieBannerView.swift
+++ b/CineHive/CineHive/Views/RecommendedMovieBannerView.swift
@@ -1,0 +1,55 @@
+//
+//  RecommendedMovieBannerView.swift
+//  CineHive
+//
+//  Created by 이종민 on 2/19/25.
+//
+
+import SwiftUI
+
+struct RecommendedMovieBanner: View {
+    let imageURL: URL?
+    let title: String
+    let subtitle: String
+    
+    var body: some View {
+        ZStack(alignment: .bottomLeading) {
+            // 배너 이미지
+            AsyncImage(url: imageURL) { image in
+                image
+                    .resizable()
+                    .scaledToFill()
+            } placeholder: {
+                Rectangle()
+                    .fill(Color.gray.opacity(0.3))
+                    .overlay(ProgressView())
+            }
+            .frame(height: 220)
+            .clipped()
+            
+            // 그라디언트 오버레이
+            LinearGradient(
+                gradient: Gradient(colors: [Color.clear, Color.black.opacity(0.7)]),
+                startPoint: .center,
+                endPoint: .bottom
+            )
+            .frame(height: 100)
+            .allowsHitTesting(false)
+            
+            // 텍스트
+            VStack(alignment: .leading, spacing: 5) {
+                Text(title)
+                    .font(.title3)
+                    .bold()
+                    .foregroundColor(.white)
+                
+                Text(subtitle)
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .padding(.top, 2)
+            }
+            .padding(.leading, 16)
+            .padding(.bottom, 12)
+        }
+    }
+}


### PR DESCRIPTION
## 작업한 내용  
- **메인 탭 뷰(MainTabView) 구성**  
  - 앱의 주요 네비게이션을 담당하는 `MainTabView` 구현
  - 각 탭에 필요한 뷰 연결 및 기본 레이아웃 구성

- **메인 화면 및 영화 리스트 뷰 구성**  
  - 메인 화면 UI 및 기본적인 영화 리스트 뷰 추가
  - SwiftUI의 `LazyVStack`을 활용하여 리스트 성능 최적화

- **홈 화면에 추천 영화 배너 추가 및 ViewModel 상태 변경**  
  - 홈 화면 상단에 추천 영화 배너 추가
  - ViewModel의 상태를 최적화하여 데이터 관리 개선

- **추천 영화 배너 컴포넌트화 및 HomeView 정리**  
  - 추천 영화 배너를 재사용 가능한 컴포넌트로 분리하여 유지보수성 향상.  
  - `HomeView`의 구조를 정리하여 코드 가독성 개선

- **추천 영화 배너 TabView로 개선 및 데이터 구조화**  
  - 추천 영화 배너를 `TabView`로 변경하여 UX 개선
  - 영화 데이터 구조를 정리하여 데이터 바인딩이 더 직관적으로 이루어지도록 변경

## PR Point  
- `MainTabView`의 구성 적절한지 검토 필요
- 재사용성을 높이는 방식 최대한 컴포넌트화 확인 필요 
- 배너 구성 괜찮은지 확인 필요

## 스크린샷  
<img alt="image" src="https://github.com/user-attachments/assets/809e21f2-9322-48dd-8a3c-27a38a28ee94" width="200">

<img alt="image" src="https://github.com/user-attachments/assets/f27ee594-6970-4d7b-83a0-5350d5699736" width="200">

<img alt="image" src="https://github.com/user-attachments/assets/b329ab18-b8b1-4876-b670-9bd65fa5dfcd" width="200">