### PR TITLE
[feature/signup-ui]: 회원가입 뷰 구현

### DIFF
--- a/CineHive/CineHive/ViewModels/SignUpViewModel.swift
+++ b/CineHive/CineHive/ViewModels/SignUpViewModel.swift
@@ -9,7 +9,11 @@ import Foundation
 
 @Observable
 class SignUpViewModel {
-    var email: String = ""
+    var email: String = "" {
+        didSet {
+            validateEmail() // 이메일 입력이 변경될 때마다 검사
+        }
+    }
     var password: String = ""
     var nickname: String = ""
     var name: String = ""
@@ -17,10 +21,28 @@ class SignUpViewModel {
     var selectedMan: Bool = false
     var selectedWoman: Bool = false
     var showPassword: Bool = false
+    var emailErrorMessage: String? = nil // 이메일 오류 메시지
     
     // 필수 필드 채워져 있는지 검사
     func isValid() -> Bool {
-        return !email.isEmpty && !password.isEmpty && !nickname.isEmpty
+        return !email.isEmpty && !password.isEmpty && !nickname.isEmpty && isValidEmail(email)
+    }
+    
+    // 이메일 정규식 검사 함수
+    func isValidEmail(_ email: String) -> Bool {
+        let emailRegex = #"^[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$"#
+        return NSPredicate(format: "SELF MATCHES %@", emailRegex).evaluate(with: email)
+    }
+    
+    // 이메일 검사 후 오류 메시지 업데이트
+    func validateEmail() {
+        if email.isEmpty {
+            emailErrorMessage = nil
+        } else if !isValidEmail(email) {
+            emailErrorMessage = "이메일의 형식이 맞지 않습니다."
+        } else {
+            emailErrorMessage = nil
+        }
     }
     
 }

--- a/CineHive/CineHive/ViewModels/SignUpViewModel.swift
+++ b/CineHive/CineHive/ViewModels/SignUpViewModel.swift
@@ -1,0 +1,26 @@
+//
+//  SignUpViewModel.swift
+//  CineHive
+//
+//  Created by 존진 on 2/18/25.
+//
+
+import Foundation
+
+@Observable
+class SignUpViewModel {
+    var email: String = ""
+    var password: String = ""
+    var nickname: String = ""
+    var name: String = ""
+    var gender: String = ""
+    var selectedMan: Bool = false
+    var selectedWoman: Bool = false
+    var showPassword: Bool = false
+    
+    // 필수 필드 채워져 있는지 검사
+    func isValid() -> Bool {
+        return !email.isEmpty && !password.isEmpty && !nickname.isEmpty
+    }
+    
+}

--- a/CineHive/CineHive/ViewModels/SignUpViewModel.swift
+++ b/CineHive/CineHive/ViewModels/SignUpViewModel.swift
@@ -17,9 +17,7 @@ class SignUpViewModel {
     var password: String = ""
     var nickname: String = ""
     var name: String = ""
-    var gender: String = ""
-    var selectedMan: Bool = false
-    var selectedWoman: Bool = false
+    var selectedGender: String = ""
     var showPassword: Bool = false
     var emailErrorMessage: String? = nil // 이메일 오류 메시지
     

--- a/CineHive/CineHive/ViewModels/SignUpViewModel.swift
+++ b/CineHive/CineHive/ViewModels/SignUpViewModel.swift
@@ -15,11 +15,20 @@ class SignUpViewModel {
         }
     }
     var password: String = ""
-    var nickname: String = ""
+    var nickname: String = "" {
+        didSet {
+            if nickname.count >= 1 {
+                validateNickname()  // 닉네임 입력 변경때마다 검사
+            } else {
+                nicknameErrorMessage = nil
+            }
+        }
+    }
     var name: String = ""
     var selectedGender: String = ""
     var showPassword: Bool = false
     var emailErrorMessage: String? = nil // 이메일 오류 메시지
+    var nicknameErrorMessage: String? = nil
     
     // 필수 필드 채워져 있는지 검사
     func isValid() -> Bool {
@@ -43,4 +52,27 @@ class SignUpViewModel {
         }
     }
     
+    // 닉네임 중복 검사
+    func validateNickname() {
+        guard let url = URL(string: "http://localhost:8081/checknickname/\(nickname)") else { return }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+
+            guard let data = data,
+                  let isAvailable = try? JSONDecoder().decode(Bool.self, from: data) else {
+                self.nicknameErrorMessage = "잘못된 응답입니다."
+                return
+            }
+            
+            if isAvailable {
+                self.nicknameErrorMessage = "사용 가능한 닉네임입니다."
+            } else {
+                self.nicknameErrorMessage = "이미 사용 중인 닉네임입니다."
+            }
+        }
+        task.resume()
+    }
 }

--- a/CineHive/CineHive/ViewModels/SignUpViewModel.swift
+++ b/CineHive/CineHive/ViewModels/SignUpViewModel.swift
@@ -29,10 +29,11 @@ class SignUpViewModel {
     var showPassword: Bool = false
     var emailErrorMessage: String? = nil // 이메일 오류 메시지
     var nicknameErrorMessage: String? = nil
+    var nicknameAvailable: Bool = false
     
-    // 필수 필드 채워져 있는지 검사
+    // 필수 필드 채워져 있는지 검사 및 닉네임 중복검사 결과 값에 따른 회원가입 버튼 활성화
     func isValid() -> Bool {
-        return !email.isEmpty && !password.isEmpty && !nickname.isEmpty && isValidEmail(email)
+        return !email.isEmpty && !password.isEmpty && !nickname.isEmpty && isValidEmail(email) && nicknameAvailable
     }
     
     // 이메일 정규식 검사 함수
@@ -69,8 +70,10 @@ class SignUpViewModel {
             
             if isAvailable {
                 self.nicknameErrorMessage = "사용 가능한 닉네임입니다."
+                self.nicknameAvailable = true
             } else {
                 self.nicknameErrorMessage = "이미 사용 중인 닉네임입니다."
+                self.nicknameAvailable = false
             }
         }
         task.resume()

--- a/CineHive/CineHive/ViewModels/SignUpViewModel.swift
+++ b/CineHive/CineHive/ViewModels/SignUpViewModel.swift
@@ -11,7 +11,10 @@ import Foundation
 class SignUpViewModel {
     var email: String = "" {
         didSet {
-            validateEmail() // 이메일 입력이 변경될 때마다 검사
+            if isValidEmail(email) {
+                checkValidateEmail()
+            }
+            validateEmail()
         }
     }
     var password: String = ""
@@ -30,6 +33,8 @@ class SignUpViewModel {
     var emailErrorMessage: String? = nil // 이메일 오류 메시지
     var nicknameErrorMessage: String? = nil
     var nicknameAvailable: Bool = false
+    var emailAvailable: Bool = false
+    var emailCheckMessage: String? = nil
     
     // 필수 필드 채워져 있는지 검사 및 닉네임 중복검사 결과 값에 따른 회원가입 버튼 활성화
     func isValid() -> Bool {
@@ -51,6 +56,32 @@ class SignUpViewModel {
         } else {
             emailErrorMessage = nil
         }
+    }
+    
+    // 이메일 중복 검사
+    func checkValidateEmail() {
+        guard let url = URL(string: "http://localhost:8081/checkemail/\(email)") else { return }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+
+            guard let data = data,
+                  let isAvailable = try? JSONDecoder().decode(Bool.self, from: data) else {
+                print("잘못된 응답입니다.")
+                return
+            }
+            
+            if isAvailable {
+                self.emailCheckMessage = "사용 가능한 이메일입니다."
+                self.emailAvailable = true
+            } else {
+                self.emailCheckMessage = "이미 사용 중인 이메일입니다."
+                self.emailAvailable = false
+            }
+        }
+        task.resume()
     }
     
     // 닉네임 중복 검사

--- a/CineHive/CineHive/ViewModels/SignUpViewModel.swift
+++ b/CineHive/CineHive/ViewModels/SignUpViewModel.swift
@@ -38,7 +38,7 @@ class SignUpViewModel {
     
     // 필수 필드 채워져 있는지 검사 및 닉네임 중복검사 결과 값에 따른 회원가입 버튼 활성화
     func isValid() -> Bool {
-        return !email.isEmpty && !password.isEmpty && !nickname.isEmpty && isValidEmail(email) && nicknameAvailable
+        return !email.isEmpty && !password.isEmpty && !nickname.isEmpty && isValidEmail(email) && nicknameAvailable && emailAvailable
     }
     
     // 이메일 정규식 검사 함수

--- a/CineHive/CineHive/Views/SignUpView.swift
+++ b/CineHive/CineHive/Views/SignUpView.swift
@@ -16,6 +16,8 @@ struct SignUpView: View {
     @State private var gender: String = ""
     @State private var selectedMan: Bool = false
     @State private var selectedWoman: Bool = false
+    @State private var showPassword: Bool = false
+
     
     var body: some View {
         VStack {
@@ -24,85 +26,10 @@ struct SignUpView: View {
                 .frame(width: 320, height: 70)
                 .font(.system(size: 22, weight: .bold))
             
-            VStack {
-                HStack {
-                        Text("이메일")
-                            .font(.system(size: 17))
-                        Text("*")
-                            .font(.system(size: 20))
-                            .foregroundStyle(.red)
-                            .offset(x: -7)
-                }
-                .frame(width: 320, height: 25, alignment: .leading)
-                
-                TextField("Email", text: $email)
-                    .frame(width: 300, height: 50)
-                    .textInputAutocapitalization(.never)    // 첫 글자 대문자 표출 X
-                    .frame(width: 330, height: 50)
-                    .overlay() {
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(Color("FontColor"), lineWidth: 0.6)
-                    }
-            }
-            .frame(width: 330, height: 90)
-            
-            VStack {
-                HStack {
-                        Text("비밀번호")
-                            .font(.system(size: 17))
-                        Text("*")
-                            .font(.system(size: 20))
-                            .foregroundStyle(.red)
-                            .offset(x: -7)
-                }
-                .frame(width: 320, height: 25, alignment: .leading)
-                TextField("Password", text: $password)
-                    .frame(width: 300, height: 50)
-                    .textInputAutocapitalization(.never)    // 첫 글자 대문자 표출 X
-                    .frame(width: 330, height: 50)
-                    .overlay() {
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(Color("FontColor"), lineWidth: 0.6)
-                    }
-            }
-            .frame(width: 330, height: 90)
-            
-            VStack {
-                HStack {
-                        Text("닉네임")
-                            .font(.system(size: 17))
-                        Text("*")
-                            .font(.system(size: 20))
-                            .foregroundStyle(.red)
-                            .offset(x: -7)
-                }
-                .frame(width: 320, height: 25, alignment: .leading)
-                
-                TextField("Nickname", text: $nickname)
-                    .frame(width: 300, height: 50)
-                    .textInputAutocapitalization(.never)    // 첫 글자 대문자 표출 X
-                    .frame(width: 330, height: 50)
-                    .overlay() {
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(Color("FontColor"), lineWidth: 0.6)
-                    }
-            }
-            .frame(width: 330, height: 90)
-            
-            VStack {
-                Text("이름")
-                    .frame(width: 320, height: 25, alignment: .leading)
-                    .font(.system(size: 17))
-                TextField("Name", text: $name)
-                    .frame(width: 300, height: 50)
-                    .textInputAutocapitalization(.never)    // 첫 글자 대문자 표출 X
-                    .frame(width: 330, height: 50)
-                    .overlay() {
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(Color("FontColor"), lineWidth: 0.6)
-                    }
-            }
-            .frame(width: 330, height: 90)
+            InputFieldView(title: "이메일", text: $email)
+            PasswordFieldView(title: "비밀번호", text: $password, showPassword: $showPassword)
+            InputFieldView(title: "닉네임", text: $nickname)
+            InputFieldView(title: "이름", text: $name)
             
             VStack {
                 Text("성별")
@@ -156,4 +83,78 @@ struct SignUpView: View {
 
 #Preview {
     SignUpView()
+}
+
+struct InputFieldView: View {
+    let title: String
+    @Binding var text: String
+    
+    var body: some View {
+        VStack {
+            HStack {
+                Text(title)
+                    .font(.system(size: 17))
+                Text("*")
+                    .font(.system(size: 20))
+                    .foregroundStyle(.red)
+                    .offset(x: -7)
+            }
+            .frame(width: 320, height: 25, alignment: .leading)
+            
+            TextField("Email", text: $text)
+                .frame(width: 300, height: 50)
+                .textInputAutocapitalization(.never)    // 첫 글자 대문자 표출 X
+                .frame(width: 330, height: 50)
+                .overlay() {
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color("FontColor"), lineWidth: 0.6)
+                }
+        }
+        .frame(width: 330, height: 90)
+    }
+}
+
+struct PasswordFieldView: View {
+    let title: String
+    @Binding var text: String
+    @Binding var showPassword: Bool
+    
+    var body: some View {
+        VStack {
+            HStack {
+                Text(title)
+                    .font(.system(size: 17))
+                Text("*")
+                    .font(.system(size: 20))
+                    .foregroundStyle(.red)
+                    .offset(x: -7)
+            }
+            .frame(width: 320, height: 25, alignment: .leading)
+            
+            HStack {
+                Section {
+                    if showPassword {
+                        TextField("Password", text: $text)
+                    } else {
+                        SecureField("Password", text: $text)
+                    }
+                }
+                .frame(width: 260, height: 40)
+                
+                Button(action: {
+                    self.showPassword.toggle()
+                }, label: {
+                    Image(systemName: showPassword ? "eye" : "eye.slash")
+                        .padding(.trailing, 1)
+                        .foregroundStyle(.gray)
+                })
+            }
+            .frame(width: 330, height: 50)
+            .overlay {
+                RoundedRectangle(cornerRadius: 13)
+                    .stroke(Color("FontColor"), lineWidth: 0.6)
+            }
+        }
+        .frame(width: 330, height: 90)
+    }
 }

--- a/CineHive/CineHive/Views/SignUpView.swift
+++ b/CineHive/CineHive/Views/SignUpView.swift
@@ -9,15 +9,7 @@ import SwiftUI
 
 struct SignUpView: View {
     
-    @State private var email: String = ""
-    @State private var password: String = ""
-    @State private var nickname: String = ""
-    @State private var name: String = ""
-    @State private var gender: String = ""
-    @State private var selectedMan: Bool = false
-    @State private var selectedWoman: Bool = false
-    @State private var showPassword: Bool = false
-
+    @State private var viewModel = SignUpViewModel()
     
     var body: some View {
         VStack {
@@ -26,10 +18,10 @@ struct SignUpView: View {
                 .frame(width: 320, height: 70)
                 .font(.system(size: 22, weight: .bold))
             
-            InputFieldView(title: "이메일", text: $email)
-            PasswordFieldView(title: "비밀번호", text: $password, showPassword: $showPassword)
-            InputFieldView(title: "닉네임", text: $nickname)
-            InputFieldView(title: "이름", text: $name, isRequired: false)
+            InputFieldView(title: "이메일", text: $viewModel.email)
+            PasswordFieldView(title: "비밀번호", text: $viewModel.password, showPassword: $viewModel.showPassword)
+            InputFieldView(title: "닉네임", text: $viewModel.nickname)
+            InputFieldView(title: "이름", text: $viewModel.name, isRequired: false)
             
             VStack {
                 Text("성별")
@@ -38,27 +30,27 @@ struct SignUpView: View {
                 
                 HStack {
                     Button(action: {
-                        selectedMan.toggle()
+                        viewModel.selectedMan.toggle()
                     }, label: {
                         Text("남자")
-                            .foregroundColor(selectedMan ? Color("LoginBtnColor") : Color("FontColor"))
+                            .foregroundColor(viewModel.selectedMan ? Color("LoginBtnColor") : Color("FontColor"))
                             .frame(width: 160, height: 50)
                     })
                     .overlay() {
                         RoundedRectangle(cornerRadius: 12)
-                            .stroke(selectedMan ? Color("LoginBtnColor") : Color("FontColor"), lineWidth: 0.6)
+                            .stroke(viewModel.selectedMan ? Color("LoginBtnColor") : Color("FontColor"), lineWidth: 0.6)
                     }
                     
                     Button(action: {
-                        selectedWoman.toggle()
+                        viewModel.selectedWoman.toggle()
                     }, label: {
                         Text("여자")
-                            .foregroundColor(selectedWoman ? Color("LoginBtnColor") : Color("FontColor"))
+                            .foregroundColor(viewModel.selectedWoman ? Color("LoginBtnColor") : Color("FontColor"))
                             .frame(width: 160, height: 50)
                     })
                     .overlay() {
                         RoundedRectangle(cornerRadius: 12)
-                            .stroke(selectedWoman ? Color("LoginBtnColor") : Color("FontColor"), lineWidth: 0.6)
+                            .stroke(viewModel.selectedWoman ? Color("LoginBtnColor") : Color("FontColor"), lineWidth: 0.6)
                     }
                 }
                 .frame(width: 330, height: 50)
@@ -67,11 +59,10 @@ struct SignUpView: View {
             .frame(width: 330, height: 90)
             
             Button(action: {
-                print("gd")
             }, label: {
                 Text("회원가입")
                     .frame(width: 330, height: 50)
-                    .background(Color("LoginBtnColor")).clipShape(RoundedRectangle(cornerRadius: 12))
+                    .background(viewModel.isValid() ? Color("LoginBtnColor"): Color.gray).clipShape(RoundedRectangle(cornerRadius: 12))
             })
             .frame(height: 90)
             .font(.system(size: 18, weight: .bold))

--- a/CineHive/CineHive/Views/SignUpView.swift
+++ b/CineHive/CineHive/Views/SignUpView.swift
@@ -31,40 +31,7 @@ struct SignUpView: View {
             InputFieldView(title: "닉네임", text: $viewModel.nickname)
             InputFieldView(title: "이름", text: $viewModel.name, isRequired: false)
             
-            VStack {
-                Text("성별")
-                    .frame(width: 320, height: 25, alignment: .leading)
-                    .font(.system(size: 17))
-                
-                HStack {
-                    Button(action: {
-                        viewModel.selectedMan.toggle()
-                    }, label: {
-                        Text("남자")
-                            .foregroundColor(viewModel.selectedMan ? Color("LoginBtnColor") : Color("FontColor"))
-                            .frame(width: 160, height: 50)
-                    })
-                    .overlay() {
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(viewModel.selectedMan ? Color("LoginBtnColor") : Color("FontColor"), lineWidth: 0.6)
-                    }
-                    
-                    Button(action: {
-                        viewModel.selectedWoman.toggle()
-                    }, label: {
-                        Text("여자")
-                            .foregroundColor(viewModel.selectedWoman ? Color("LoginBtnColor") : Color("FontColor"))
-                            .frame(width: 160, height: 50)
-                    })
-                    .overlay() {
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(viewModel.selectedWoman ? Color("LoginBtnColor") : Color("FontColor"), lineWidth: 0.6)
-                    }
-                }
-                .frame(width: 330, height: 50)
-   
-            }
-            .frame(width: 330, height: 90)
+            GenderSelectedView(selectedGender: $viewModel.selectedGender)
             
             Button(action: {
             }, label: {
@@ -157,6 +124,36 @@ struct PasswordFieldView: View {
             .overlay {
                 RoundedRectangle(cornerRadius: 13)
                     .stroke(Color("FontColor"), lineWidth: 0.6)
+            }
+        }
+        .frame(width: 330, height: 90)
+    }
+}
+
+struct GenderSelectedView: View {
+    @Binding var selectedGender: String
+    let genders: [String] = ["남자", "여자"]
+    
+    var body: some View {
+        VStack {
+            Text("성별")
+                .frame(width: 320, height: 25, alignment: .leading)
+                .font(.system(size: 17))
+            
+            HStack {
+                ForEach(genders, id: \.self) { gender in
+                    Button(action: {
+                        selectedGender = gender
+                    }) {
+                        Text(gender)
+                            .foregroundColor(selectedGender == gender ? Color("LoginBtnColor") : Color("FontColor"))
+                            .frame(width: 160, height: 50)
+                    }
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(selectedGender == gender ? Color("LoginBtnColor") : Color("FontColor"), lineWidth: 0.6)
+                    )
+                }
             }
         }
         .frame(width: 330, height: 90)

--- a/CineHive/CineHive/Views/SignUpView.swift
+++ b/CineHive/CineHive/Views/SignUpView.swift
@@ -67,6 +67,7 @@ struct SignUpView: View {
             .frame(height: 90)
             .font(.system(size: 18, weight: .bold))
             .foregroundStyle(.white)
+            .disabled(!viewModel.isValid())
             Spacer()
         }
     }

--- a/CineHive/CineHive/Views/SignUpView.swift
+++ b/CineHive/CineHive/Views/SignUpView.swift
@@ -29,7 +29,7 @@ struct SignUpView: View {
             InputFieldView(title: "이메일", text: $email)
             PasswordFieldView(title: "비밀번호", text: $password, showPassword: $showPassword)
             InputFieldView(title: "닉네임", text: $nickname)
-            InputFieldView(title: "이름", text: $name)
+            InputFieldView(title: "이름", text: $name, isRequired: false)
             
             VStack {
                 Text("성별")
@@ -88,20 +88,24 @@ struct SignUpView: View {
 struct InputFieldView: View {
     let title: String
     @Binding var text: String
+    var isRequired: Bool = true
     
     var body: some View {
         VStack {
             HStack {
                 Text(title)
                     .font(.system(size: 17))
-                Text("*")
-                    .font(.system(size: 20))
-                    .foregroundStyle(.red)
-                    .offset(x: -7)
+                // isRequired가 true일 때만 * 표시
+                if isRequired {
+                    Text("*")
+                        .font(.system(size: 20))
+                        .foregroundStyle(.red)
+                        .offset(x: -7)
+                }
             }
             .frame(width: 320, height: 25, alignment: .leading)
             
-            TextField("Email", text: $text)
+            TextField("", text: $text)
                 .frame(width: 300, height: 50)
                 .textInputAutocapitalization(.never)    // 첫 글자 대문자 표출 X
                 .frame(width: 330, height: 50)
@@ -134,9 +138,9 @@ struct PasswordFieldView: View {
             HStack {
                 Section {
                     if showPassword {
-                        TextField("Password", text: $text)
+                        TextField("", text: $text)
                     } else {
-                        SecureField("Password", text: $text)
+                        SecureField("", text: $text)
                     }
                 }
                 .frame(width: 260, height: 40)

--- a/CineHive/CineHive/Views/SignUpView.swift
+++ b/CineHive/CineHive/Views/SignUpView.swift
@@ -19,6 +19,14 @@ struct SignUpView: View {
                 .font(.system(size: 22, weight: .bold))
             
             InputFieldView(title: "이메일", text: $viewModel.email)
+            // 오류 메시지
+            if let emailError = viewModel.emailErrorMessage {
+                Text(emailError)
+                    .font(.system(size: 14))
+                    .foregroundColor(.red)
+                    .frame(width: 320, height: 20, alignment: .leading)
+            }
+                
             PasswordFieldView(title: "비밀번호", text: $viewModel.password, showPassword: $viewModel.showPassword)
             InputFieldView(title: "닉네임", text: $viewModel.nickname)
             InputFieldView(title: "이름", text: $viewModel.name, isRequired: false)

--- a/CineHive/CineHive/Views/SignUpView.swift
+++ b/CineHive/CineHive/Views/SignUpView.swift
@@ -14,6 +14,8 @@ struct SignUpView: View {
     @State private var nickname: String = ""
     @State private var name: String = ""
     @State private var gender: String = ""
+    @State private var selectedMan: Bool = false
+    @State private var selectedWoman: Bool = false
     
     var body: some View {
         VStack {
@@ -106,14 +108,34 @@ struct SignUpView: View {
                 Text("성별")
                     .frame(width: 320, height: 25, alignment: .leading)
                     .font(.system(size: 17))
-                TextField("Gender", text: $gender)
-                    .frame(width: 300, height: 50)
-                    .textInputAutocapitalization(.never)    // 첫 글자 대문자 표출 X
-                    .frame(width: 330, height: 50)
+                
+                HStack {
+                    Button(action: {
+                        selectedMan.toggle()
+                    }, label: {
+                        Text("남자")
+                            .foregroundColor(selectedMan ? Color("LoginBtnColor") : Color("FontColor"))
+                            .frame(width: 160, height: 50)
+                    })
                     .overlay() {
                         RoundedRectangle(cornerRadius: 12)
-                            .stroke(Color("FontColor"), lineWidth: 0.6)
+                            .stroke(selectedMan ? Color("LoginBtnColor") : Color("FontColor"), lineWidth: 0.6)
                     }
+                    
+                    Button(action: {
+                        selectedWoman.toggle()
+                    }, label: {
+                        Text("여자")
+                            .foregroundColor(selectedWoman ? Color("LoginBtnColor") : Color("FontColor"))
+                            .frame(width: 160, height: 50)
+                    })
+                    .overlay() {
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(selectedWoman ? Color("LoginBtnColor") : Color("FontColor"), lineWidth: 0.6)
+                    }
+                }
+                .frame(width: 330, height: 50)
+   
             }
             .frame(width: 330, height: 90)
             

--- a/CineHive/CineHive/Views/SignUpView.swift
+++ b/CineHive/CineHive/Views/SignUpView.swift
@@ -8,8 +8,127 @@
 import SwiftUI
 
 struct SignUpView: View {
+    
+    @State private var email: String = ""
+    @State private var password: String = ""
+    @State private var nickname: String = ""
+    @State private var name: String = ""
+    @State private var gender: String = ""
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack {
+            Spacer()
+            Text("Create Account")
+                .frame(width: 320, height: 70)
+                .font(.system(size: 22, weight: .bold))
+            
+            VStack {
+                HStack {
+                        Text("이메일")
+                            .font(.system(size: 17))
+                        Text("*")
+                            .font(.system(size: 20))
+                            .foregroundStyle(.red)
+                            .offset(x: -7)
+                }
+                .frame(width: 320, height: 25, alignment: .leading)
+                
+                TextField("Email", text: $email)
+                    .frame(width: 300, height: 50)
+                    .textInputAutocapitalization(.never)    // 첫 글자 대문자 표출 X
+                    .frame(width: 330, height: 50)
+                    .overlay() {
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color("FontColor"), lineWidth: 0.6)
+                    }
+            }
+            .frame(width: 330, height: 90)
+            
+            VStack {
+                HStack {
+                        Text("비밀번호")
+                            .font(.system(size: 17))
+                        Text("*")
+                            .font(.system(size: 20))
+                            .foregroundStyle(.red)
+                            .offset(x: -7)
+                }
+                .frame(width: 320, height: 25, alignment: .leading)
+                TextField("Password", text: $password)
+                    .frame(width: 300, height: 50)
+                    .textInputAutocapitalization(.never)    // 첫 글자 대문자 표출 X
+                    .frame(width: 330, height: 50)
+                    .overlay() {
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color("FontColor"), lineWidth: 0.6)
+                    }
+            }
+            .frame(width: 330, height: 90)
+            
+            VStack {
+                HStack {
+                        Text("닉네임")
+                            .font(.system(size: 17))
+                        Text("*")
+                            .font(.system(size: 20))
+                            .foregroundStyle(.red)
+                            .offset(x: -7)
+                }
+                .frame(width: 320, height: 25, alignment: .leading)
+                
+                TextField("Nickname", text: $nickname)
+                    .frame(width: 300, height: 50)
+                    .textInputAutocapitalization(.never)    // 첫 글자 대문자 표출 X
+                    .frame(width: 330, height: 50)
+                    .overlay() {
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color("FontColor"), lineWidth: 0.6)
+                    }
+            }
+            .frame(width: 330, height: 90)
+            
+            VStack {
+                Text("이름")
+                    .frame(width: 320, height: 25, alignment: .leading)
+                    .font(.system(size: 17))
+                TextField("Name", text: $name)
+                    .frame(width: 300, height: 50)
+                    .textInputAutocapitalization(.never)    // 첫 글자 대문자 표출 X
+                    .frame(width: 330, height: 50)
+                    .overlay() {
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color("FontColor"), lineWidth: 0.6)
+                    }
+            }
+            .frame(width: 330, height: 90)
+            
+            VStack {
+                Text("성별")
+                    .frame(width: 320, height: 25, alignment: .leading)
+                    .font(.system(size: 17))
+                TextField("Gender", text: $gender)
+                    .frame(width: 300, height: 50)
+                    .textInputAutocapitalization(.never)    // 첫 글자 대문자 표출 X
+                    .frame(width: 330, height: 50)
+                    .overlay() {
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color("FontColor"), lineWidth: 0.6)
+                    }
+            }
+            .frame(width: 330, height: 90)
+            
+            Button(action: {
+                print("gd")
+            }, label: {
+                Text("회원가입")
+                    .frame(width: 330, height: 50)
+                    .background(Color("LoginBtnColor")).clipShape(RoundedRectangle(cornerRadius: 12))
+            })
+            .frame(height: 90)
+            .font(.system(size: 18, weight: .bold))
+            .foregroundStyle(.white)
+            Spacer()
+        }
     }
 }
 

--- a/CineHive/CineHive/Views/SignUpView.swift
+++ b/CineHive/CineHive/Views/SignUpView.swift
@@ -50,9 +50,7 @@ struct SignUpView: View {
             GenderSelectedView(selectedGender: $viewModel.selectedGender)
             
             Button(action: {
-//                if !viewModel.emailAvailable {
-//                    
-//                }
+            // 로그인 화면으로 전환하는 코드 필요
             }, label: {
                 Text("회원가입")
                     .frame(width: 330, height: 50)

--- a/CineHive/CineHive/Views/SignUpView.swift
+++ b/CineHive/CineHive/Views/SignUpView.swift
@@ -29,6 +29,14 @@ struct SignUpView: View {
                 
             PasswordFieldView(title: "비밀번호", text: $viewModel.password, showPassword: $viewModel.showPassword)
             InputFieldView(title: "닉네임", text: $viewModel.nickname)
+            // 닉네임 중복 검사 결과 메시지 표시
+            if let nicknameError = viewModel.nicknameErrorMessage {
+                Text(nicknameError)
+                    .font(.system(size: 14))
+                    .foregroundColor(nicknameError == "사용 가능한 닉네임입니다." ? .green : .red)
+                    .frame(width: 330, alignment: .leading)
+                    .padding(.top, 1)
+            }
             InputFieldView(title: "이름", text: $viewModel.name, isRequired: false)
             
             GenderSelectedView(selectedGender: $viewModel.selectedGender)

--- a/CineHive/CineHive/Views/SignUpView.swift
+++ b/CineHive/CineHive/Views/SignUpView.swift
@@ -26,6 +26,14 @@ struct SignUpView: View {
                     .foregroundColor(.red)
                     .frame(width: 320, height: 20, alignment: .leading)
             }
+            
+            // 이메일 중복 검사 결과 표시 (형식 오류가 없을 때만 표시)
+            else if let emailCheck = viewModel.emailCheckMessage {
+                Text(emailCheck)
+                    .font(.system(size: 14))
+                    .foregroundColor(emailCheck == "사용 가능한 이메일입니다." ? .green : .red)
+                    .frame(width: 330, alignment: .leading)
+            }
                 
             PasswordFieldView(title: "비밀번호", text: $viewModel.password, showPassword: $viewModel.showPassword)
             InputFieldView(title: "닉네임", text: $viewModel.nickname)
@@ -42,6 +50,9 @@ struct SignUpView: View {
             GenderSelectedView(selectedGender: $viewModel.selectedGender)
             
             Button(action: {
+//                if !viewModel.emailAvailable {
+//                    
+//                }
             }, label: {
                 Text("회원가입")
                     .frame(width: 330, height: 50)


### PR DESCRIPTION
## 작업한 내용
- SignUpView, SignUpViewModel 생성
- 이메일 정규식 검사 구현
    - 이메일 형식 불일치 시 "이메일의 형식이 맞지 않습니다." 메시지 출력
- 닉네임 중복 검사 구현
    - 한글자 이상 입력 시 중복 검사 실행
- 이메일 중복 검사 구현
    - 이메일 정규식 검사 이후 검사할 수 있도록 구현
- 회원가입 버튼 비활성화 처리 구현
    - 닉네임 중복
    - 이메일 형식 불일치 시
    - 이메일 중복
    - 필수 입력 필드 미기입 시

## PR Point
- 닉네임 중복검사 API 연동
- UI에서 닉네임 사용 가능 여부, 이메일 정규식 검사 결과, 이메일 중복 검사 결과 실시간 반영

## 스크린샷

<img src="https://github.com/user-attachments/assets/a95f0143-d90d-4746-8a42-d463b4d698bb" width="200">
<img src="https://github.com/user-attachments/assets/8b478634-4055-4abb-90a1-5bdb86f56162" width="200">
<img src="https://github.com/user-attachments/assets/a4734318-2d49-456f-9204-b77a0fc13ab9" width="200">

