### PR TITLE
[feature/signup] 회원가입 로직 구현

### DIFF
--- a/CineHive/CineHive/Models/SignUpResponse.swift
+++ b/CineHive/CineHive/Models/SignUpResponse.swift
@@ -1,0 +1,13 @@
+//
+//  SignUpResponse.swift
+//  CineHive
+//
+//  Created by 존진 on 2/28/25.
+//
+
+import Foundation
+
+struct SignUpResponse: Codable {
+    let message: String
+    let status: String
+}

--- a/CineHive/CineHive/Models/User.swift
+++ b/CineHive/CineHive/Models/User.swift
@@ -1,0 +1,39 @@
+//
+//  User.swift
+//  CineHive
+//
+//  Created by 존진 on 2/22/25.
+//
+
+import Foundation
+
+struct User: Codable, Identifiable {
+    let id: Int?
+    let email: String
+    let password: String
+    let nickname: String
+    let name: String?
+    let gender: String?
+    let type: String
+    
+    enum CodingKeys: String, CodingKey {
+        case id = "mem_id"
+        case email = "memEmail"
+        case password = "memPassword"
+        case nickname = "memNickname"
+        case name = "memName"
+        case gender = "memSex"
+        case type = "memType"
+    }
+    
+    // 기본 생성자
+    init(id: Int? = nil, email: String, password: String, nickname: String, name: String?, gender: String?, type: String) {
+        self.id = id
+        self.email = email
+        self.password = password
+        self.nickname = nickname
+        self.name = name
+        self.gender = gender
+        self.type = type
+    }
+}

--- a/CineHive/CineHive/Network/NetworkManager.swift
+++ b/CineHive/CineHive/Network/NetworkManager.swift
@@ -72,5 +72,46 @@ final class NetworkManager {
             throw NetworkError.decodingError(error)
         }
     }
+    
+    // 공통 POST 요청 함수
+    func post<T: Decodable, U: Encodable>(endpoint: String, body: U) async throws -> T {
+        guard let url = URL(string: "\(baseURL)\(endpoint)") else {
+            throw NetworkError.invalidURL
+        }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        // Encodable 데이터 -> JSON 형식 변환
+        let encoder = JSONEncoder()
+        guard let jsonData = try? encoder.encode(body) else {
+            throw NetworkError.decodingError(NSError(domain: "Encoding Error", code: -1, userInfo: nil))
+        }
+        
+        request.httpBody = jsonData
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+        
+        guard (200...299).contains(httpResponse.statusCode) else {
+            if let responseString = String(data: data, encoding: .utf8) {
+                print("서버 응답 메시지: \(responseString)") // 서버가 반환한 오류 메시지를 확인
+            }
+            throw NetworkError.badResponse(statusCode: httpResponse.statusCode)
+        }
+        
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            if let responseString = String(data: data, encoding: .utf8) {
+                print("서버 응답 원본 데이터: \(responseString)") // 서버가 보낸 데이터를 확인
+            }
+            throw NetworkError.decodingError(error)
+        }
+    }
 }
 

--- a/CineHive/CineHive/Services/UserService.swift
+++ b/CineHive/CineHive/Services/UserService.swift
@@ -19,13 +19,13 @@ final class UserService {
     
     // 닉네임 중복 확인 요청 (GET)
     func fetchUserNickname(nickname: String) async throws -> Bool {
-        let endpoint = "/checknickname\(nickname)"
+        let endpoint = "/checknickname/\(nickname)"
         return try await NetworkManager.shared.fetch(endpoint: endpoint)
     }
     
     // 이메일 중복 확인 요청 (GET)
     func fetchUserEmail(email: String) async throws -> Bool {
-        let endpoint = "/checkemail\(email)"
+        let endpoint = "/checkemail/\(email)"
         return try await NetworkManager.shared.fetch(endpoint: endpoint)
     }
 }

--- a/CineHive/CineHive/Services/UserService.swift
+++ b/CineHive/CineHive/Services/UserService.swift
@@ -1,0 +1,21 @@
+//
+//  UserService.swift
+//  CineHive
+//
+//  Created by 존진 on 2/22/25.
+//
+
+import Foundation
+
+final class UserService {
+    static let shared = UserService()
+    private init() {}
+    
+    private let userEndpoint = "/checknickname"
+    
+    // 회원가입 요청 (POST)
+    func registerUser(user: User) async throws -> SignUpResponse {
+        let endpoint = "/register"
+        return try await NetworkManager.shared.post(endpoint: endpoint, body: user)
+    }
+}

--- a/CineHive/CineHive/Services/UserService.swift
+++ b/CineHive/CineHive/Services/UserService.swift
@@ -11,11 +11,21 @@ final class UserService {
     static let shared = UserService()
     private init() {}
     
-    private let userEndpoint = "/checknickname"
-    
     // 회원가입 요청 (POST)
     func registerUser(user: User) async throws -> SignUpResponse {
         let endpoint = "/register"
         return try await NetworkManager.shared.post(endpoint: endpoint, body: user)
+    }
+    
+    // 닉네임 중복 확인 요청 (GET)
+    func fetchUserNickname(nickname: String) async throws -> Bool {
+        let endpoint = "/checknickname\(nickname)"
+        return try await NetworkManager.shared.fetch(endpoint: endpoint)
+    }
+    
+    // 이메일 중복 확인 요청 (GET)
+    func fetchUserEmail(email: String) async throws -> Bool {
+        let endpoint = "/checkemail\(email)"
+        return try await NetworkManager.shared.fetch(endpoint: endpoint)
     }
 }

--- a/CineHive/CineHive/ViewModels/SignUpViewModel.swift
+++ b/CineHive/CineHive/ViewModels/SignUpViewModel.swift
@@ -12,7 +12,9 @@ class SignUpViewModel {
     var email: String = "" {
         didSet {
             if isValidEmail(email) {
-                checkValidateEmail()
+                Task {
+                    await checkValidateEmail()
+                }
             }
             validateEmail()
         }
@@ -21,7 +23,9 @@ class SignUpViewModel {
     var nickname: String = "" {
         didSet {
             if nickname.count >= 1 {
-                validateNickname()  // 닉네임 입력 변경때마다 검사
+                Task {
+                    await validateNickname()  // 닉네임 입력 변경때마다 검사
+                }
             } else {
                 nicknameErrorMessage = nil
             }
@@ -36,6 +40,11 @@ class SignUpViewModel {
     var emailAvailable: Bool = false
     var emailCheckMessage: String? = nil
     var isSignUpSuccess: Bool = false
+    private let userService: UserService
+    
+    init(userService: UserService = .shared) {
+        self.userService = userService
+    }
     
     // 필수 필드 채워져 있는지 검사 및 닉네임 중복검사 결과 값에 따른 회원가입 버튼 활성화
     func isValid() -> Bool {
@@ -60,20 +69,10 @@ class SignUpViewModel {
     }
     
     // 이메일 중복 검사
-    func checkValidateEmail() {
-        guard let url = URL(string: "http://localhost:8081/checkemail/\(email)") else { return }
-        
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        
-        let task = URLSession.shared.dataTask(with: request) { data, response, error in
-
-            guard let data = data,
-                  let isAvailable = try? JSONDecoder().decode(Bool.self, from: data) else {
-                print("잘못된 응답입니다.")
-                return
-            }
-            
+    @MainActor
+    func checkValidateEmail() async {
+        do {
+            let isAvailable = try await userService.fetchUserEmail(email: email)
             if isAvailable {
                 self.emailCheckMessage = "사용 가능한 이메일입니다."
                 self.emailAvailable = true
@@ -81,25 +80,17 @@ class SignUpViewModel {
                 self.emailCheckMessage = "이미 사용 중인 이메일입니다."
                 self.emailAvailable = false
             }
+        } catch {
+            self.emailErrorMessage = "이메일 중복 검사 실패: \(error.localizedDescription)"
+            self.emailAvailable = false
         }
-        task.resume()
     }
     
     // 닉네임 중복 검사
-    func validateNickname() {
-        guard let url = URL(string: "http://localhost:8081/checknickname/\(nickname)") else { return }
-        
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        
-        let task = URLSession.shared.dataTask(with: request) { data, response, error in
-
-            guard let data = data,
-                  let isAvailable = try? JSONDecoder().decode(Bool.self, from: data) else {
-                self.nicknameErrorMessage = "잘못된 응답입니다."
-                return
-            }
-            
+    @MainActor
+    func validateNickname() async {
+        do {
+            let isAvailable = try await userService.fetchUserNickname(nickname: nickname)
             if isAvailable {
                 self.nicknameErrorMessage = "사용 가능한 닉네임입니다."
                 self.nicknameAvailable = true
@@ -107,8 +98,10 @@ class SignUpViewModel {
                 self.nicknameErrorMessage = "이미 사용 중인 닉네임입니다."
                 self.nicknameAvailable = false
             }
+        } catch {
+            self.nicknameErrorMessage = "닉네임 중복 검사 실패: \(error.localizedDescription)"
+            self.nicknameAvailable = false
         }
-        task.resume()
     }
     
     // 회원가입

--- a/CineHive/CineHive/ViewModels/SignUpViewModel.swift
+++ b/CineHive/CineHive/ViewModels/SignUpViewModel.swift
@@ -28,13 +28,14 @@ class SignUpViewModel {
         }
     }
     var name: String = ""
-    var selectedGender: String = ""
+    var gender: String = ""
     var showPassword: Bool = false
     var emailErrorMessage: String? = nil // 이메일 오류 메시지
     var nicknameErrorMessage: String? = nil
     var nicknameAvailable: Bool = false
     var emailAvailable: Bool = false
     var emailCheckMessage: String? = nil
+    var isSignUpSuccess: Bool = false
     
     // 필수 필드 채워져 있는지 검사 및 닉네임 중복검사 결과 값에 따른 회원가입 버튼 활성화
     func isValid() -> Bool {
@@ -108,5 +109,39 @@ class SignUpViewModel {
             }
         }
         task.resume()
+    }
+    
+    // 회원가입
+    @MainActor
+    func signUp() async {
+        
+        let newUser = User(
+            email: email,
+            password: password,
+            nickname: nickname,
+            name: name.isEmpty ? nil : name,
+            gender: gender.isEmpty ? nil : gender,
+            type: "일반"
+        )
+        
+        // newUser 객체 -> JSON으로 변환되는지
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .prettyPrinted
+            _ = try encoder.encode(newUser)
+        } catch {
+            print("JSON 변환 실패: \(error)")
+        }
+        
+        do {
+            let response = try await UserService.shared.registerUser(user: newUser)
+            print("서버 응답 메시지: \(response.message), 상태: \(response.status)")
+            
+            if response.status == "success" {
+                self.isSignUpSuccess = true // 회원가입 성공 후 로그인 화면으로 이동
+            }
+        } catch {
+            print("회원가입 실패: \(error.localizedDescription)")
+        }
     }
 }

--- a/CineHive/CineHive/Views/SignUpView.swift
+++ b/CineHive/CineHive/Views/SignUpView.swift
@@ -12,56 +12,64 @@ struct SignUpView: View {
     @State private var viewModel = SignUpViewModel()
     
     var body: some View {
-        VStack {
-            Spacer()
-            Text("Create Account")
-                .frame(width: 320, height: 70)
-                .font(.system(size: 22, weight: .bold))
-            
-            InputFieldView(title: "이메일", text: $viewModel.email)
-            // 오류 메시지
-            if let emailError = viewModel.emailErrorMessage {
-                Text(emailError)
-                    .font(.system(size: 14))
-                    .foregroundColor(.red)
-                    .frame(width: 320, height: 20, alignment: .leading)
-            }
-            
-            // 이메일 중복 검사 결과 표시 (형식 오류가 없을 때만 표시)
-            else if let emailCheck = viewModel.emailCheckMessage {
-                Text(emailCheck)
-                    .font(.system(size: 14))
-                    .foregroundColor(emailCheck == "사용 가능한 이메일입니다." ? .green : .red)
-                    .frame(width: 330, alignment: .leading)
-            }
+        NavigationStack {
+            VStack {
+                Spacer()
+                Text("Create Account")
+                    .frame(width: 320, height: 70)
+                    .font(.system(size: 22, weight: .bold))
                 
-            PasswordFieldView(title: "비밀번호", text: $viewModel.password, showPassword: $viewModel.showPassword)
-            InputFieldView(title: "닉네임", text: $viewModel.nickname)
-            // 닉네임 중복 검사 결과 메시지 표시
-            if let nicknameError = viewModel.nicknameErrorMessage {
-                Text(nicknameError)
-                    .font(.system(size: 14))
-                    .foregroundColor(nicknameError == "사용 가능한 닉네임입니다." ? .green : .red)
-                    .frame(width: 330, alignment: .leading)
-                    .padding(.top, 1)
+                InputFieldView(title: "이메일", text: $viewModel.email)
+                // 오류 메시지
+                if let emailError = viewModel.emailErrorMessage {
+                    Text(emailError)
+                        .font(.system(size: 14))
+                        .foregroundColor(.red)
+                        .frame(width: 320, height: 20, alignment: .leading)
+                }
+                
+                // 이메일 중복 검사 결과 표시 (형식 오류가 없을 때만 표시)
+                else if let emailCheck = viewModel.emailCheckMessage {
+                    Text(emailCheck)
+                        .font(.system(size: 14))
+                        .foregroundColor(emailCheck == "사용 가능한 이메일입니다." ? .green : .red)
+                        .frame(width: 330, alignment: .leading)
+                }
+                    
+                PasswordFieldView(title: "비밀번호", text: $viewModel.password, showPassword: $viewModel.showPassword)
+                InputFieldView(title: "닉네임", text: $viewModel.nickname)
+                // 닉네임 중복 검사 결과 메시지 표시
+                if let nicknameError = viewModel.nicknameErrorMessage {
+                    Text(nicknameError)
+                        .font(.system(size: 14))
+                        .foregroundColor(nicknameError == "사용 가능한 닉네임입니다." ? .green : .red)
+                        .frame(width: 330, alignment: .leading)
+                        .padding(.top, 1)
+                }
+                InputFieldView(title: "이름", text: $viewModel.name, isRequired: false)
+                
+                GenderSelectedView(selectedGender: $viewModel.gender)
+                
+                Button(action: {
+                    Task {
+                        await viewModel.signUp()
+                    }
+                }, label: {
+                    Text("회원가입")
+                        .frame(width: 330, height: 50)
+                        .background(viewModel.isValid() ? Color("LoginBtnColor"): Color.gray).clipShape(RoundedRectangle(cornerRadius: 12))
+                })
+                .frame(height: 90)
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(.white)
+                .disabled(!viewModel.isValid())
+                Spacer()
             }
-            InputFieldView(title: "이름", text: $viewModel.name, isRequired: false)
-            
-            GenderSelectedView(selectedGender: $viewModel.selectedGender)
-            
-            Button(action: {
-            // 로그인 화면으로 전환하는 코드 필요
-            }, label: {
-                Text("회원가입")
-                    .frame(width: 330, height: 50)
-                    .background(viewModel.isValid() ? Color("LoginBtnColor"): Color.gray).clipShape(RoundedRectangle(cornerRadius: 12))
-            })
-            .frame(height: 90)
-            .font(.system(size: 18, weight: .bold))
-            .foregroundStyle(.white)
-            .disabled(!viewModel.isValid())
-            Spacer()
+            .navigationDestination(isPresented: $viewModel.isSignUpSuccess) {
+                LoginView()
+            }
         }
+        
     }
 }
 


### PR DESCRIPTION
## 작업한 내용
- NetworkManager.swift에서 공통 POST 함수 작성
- SwiftUI `navigationDestination(isPresented:)` 설정 오류 해결
    - NavigationStack 추가
- 서버 응답을 'SignUpResponse' 모델로 디코딩하여 처리하도록 변경
-  isSignUpSuccess의 변경이 UI에 반영되도록 '@MainActor'를 사용
    - UI 업데이트가 메인 스레드에서 실행되도록 보장
- 닉네임 및 이메일 중복 확인 API 요청 함수 리팩토링
    - 중복 검사 API 요청을 명확하게 분리하여 가독성 및 유지보수성 향상
- 닉네임 및 이메일 중복 검사 로직 서비스로 분리
    -  네트워크 요청 UserService로 분리

## PR Point
- navigationDestination(isPresented:) 설정이 올바르게 적용되었는지 확인
- 네트워크 요청코드 UserService로 분리
- 중복 검사 API 요청을 명확하게 분리하여 가독성 및 유지보수성 향상

## 스크린샷
X