### PR TITLE
[feature/detail]:showAvailabilitySheetState 상태 변수 추가 및 ViewModel 상태 반영 개선

### DIFF
--- a/CineHive/CineHive/Views/Detail/Tab/DetailActionButtonsView.swift
+++ b/CineHive/CineHive/Views/Detail/Tab/DetailActionButtonsView.swift
@@ -14,7 +14,7 @@ struct DetailActionButtonsView: View {
     
     @Bindable private var viewModel = DetailActionButtonsViewModel()
     @State private var showShareSheetState: Bool = false
-    
+    @State private var showAvailabilitySheetState: Bool = false
     
     var body: some View {
         HStack(spacing: 0) {
@@ -32,12 +32,20 @@ struct DetailActionButtonsView: View {
                 imageName: "tv",
                 text: "시청 정보",
                 textColor: textColor,
-                action: viewModel.openAvailabilitySheet
+                action: {
+                    viewModel.openAvailabilitySheet()
+                    showAvailabilitySheetState = true
+                }
             )
-            .sheet(isPresented: $viewModel.showAvailabilitySheet) {
+            .sheet(isPresented: $showAvailabilitySheetState, onDismiss: {
+                viewModel.closeAvailabilitySheet()
+            }) {
                 PlatformInfoSheetView(
                     movie: movie,
-                    onDismiss: viewModel.closeAvailabilitySheet
+                    onDismiss: {
+                        viewModel.closeAvailabilitySheet()
+                        showAvailabilitySheetState = false
+                    }
                 )
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)


### PR DESCRIPTION
## 작업한 내용  
- **DetailActionButtonsView 상태 관리 개선**  
  - `showAvailabilitySheetState` 상태 변수를 추가하여 시청 정보 시트 표시 상태 관리  
  - 기존 `viewModel.showAvailabilitySheet` 직접 바인딩 방식에서 독립적인 `State` 변수 활용하여 상태 분리  

- **ViewModel 상태 반영 로직 수정**  
  - `viewModel.openAvailabilitySheet()` 호출 시 `showAvailabilitySheetState = true` 설정  
  - `sheet` 닫힐 때 `viewModel.closeAvailabilitySheet()` 호출 후 `showAvailabilitySheetState = false`로 변경  
  - `onDismiss` 핸들러를 추가하여 ViewModel과 View의 상태가 동기화되도록 개선  

- **시청 정보 시트 표시 방식 개선**  
  - `.sheet(isPresented:)`에서 `viewModel.showAvailabilitySheet` → `showAvailabilitySheetState`로 변경  
  - `PlatformInfoSheetView`의 `onDismiss` 콜백을 통해 `viewModel.closeAvailabilitySheet()` 호출  

## PR Point  
- `showAvailabilitySheetState` 적용으로 인해 ViewModel과 View의 상태가 정상적으로 동작하는지 확인  
- `PlatformInfoSheetView`가 `sheet`로 올바르게 표시되고 닫힐 때 상태가 초기화되는지 테스트 필요  

## 스크린샷  
N/A  