### PR TITLE
[Refactor/network-endpoint]: EndPoint enum 정리 및 NetworkManager 개선

### DIFF
--- a/CineHive/CineHive/Network/EndPoint.swift
+++ b/CineHive/CineHive/Network/EndPoint.swift
@@ -1,0 +1,159 @@
+//
+//  EndPoint.swift
+//  CineHive
+//
+//  Created by 이종민 on 3/29/25.
+//
+
+import Foundation
+
+enum EndPoint {
+    static let baseURL = "http://localhost:8081"
+
+    enum NowPlaying {
+        static let get = "/now_playing"
+        static let update = "/update_now_playing"
+    }
+
+    enum ReplyBookMark {
+        static let toggle = "/reply/bookmark/toggle"
+        static let count = "/reply/bookmark/count"
+    }
+
+    enum Animation {
+        static let list = "/animations"
+        static func detail(_ id: Int) -> String { "/animations/\(id)" }
+        static func similar(_ id: Int) -> String { "/animations/\(id)/similar" }
+    }
+
+    enum UpComingMovie {
+        static let update = "/update_upcoming_movie"
+        static let list = "/get_upcoming_movies"
+    }
+
+    enum PopularMovie {
+        static let update = "/update_popular_movie"
+        static let list = "/get_popular_movies"
+    }
+
+    enum TopMovie {
+        static let update = "/update_top_movie"
+        static let list = "/get_topmovies"
+    }
+
+    enum Movie {
+        static let list = "/movies"
+        static func detail(_ id: Int) -> String { "/movies/\(id)" }
+        static func similar(_ id: Int) -> String { "/movies/\(id)/similar" }
+    }
+
+    enum Drama {
+        static let list = "/dramas"
+        static func detail(_ id: Int) -> String { "/dramas/\(id)" }
+    }
+
+    enum Search {
+        static let search = "/search"
+    }
+
+    enum Reply {
+        static let register = "/reply"
+        static func userReplies(_ email: String) -> String { "/reply/user/\(email)" }
+        static func movieReplies(_ movieId: Int) -> String { "/reply/movie/\(movieId)" }
+        static func delete(movieId: Int, replyId: Int) -> String {
+            "/reply/\(movieId)/\(replyId)"
+        }
+    }
+
+    enum ReplyJudge {
+        static let like = "/reply/judge/like"
+        static let dislike = "/reply/judge/dislike"
+        static let likeCount = "/reply/judge/count/like"
+        static let dislikeCount = "/reply/judge/count/dislike"
+    }
+
+    enum Board {
+        static func detail(_ id: Int) -> String { "/boards/\(id)" }
+        static func update(_ id: Int) -> String { "/boards/\(id)" }
+        static func delete(_ id: Int) -> String { "/boards/\(id)" }
+        static let register = "/boards"
+        static let search = "/boards/search"
+        static let all = "/boards/all"
+    }
+
+    enum Comment {
+        static func update(boardId: Int, commentId: Int) -> String {
+            "/comment/\(boardId)/board/update/\(commentId)"
+        }
+        static func register(_ boardId: Int) -> String { "/comment/\(boardId)" }
+        static func list(_ boardId: Int) -> String { "/comment/\(boardId)/board/all" }
+        static func delete(boardId: Int, commentId: Int) -> String {
+            "/comment/\(boardId)/board/delete/\(commentId)"
+        }
+    }
+
+    enum Like {
+        static func like(_ boardId: Int) -> String { "/like/\(boardId)" }
+        static func cancel(_ boardId: Int) -> String { "/like/\(boardId)" }
+        static func count(_ boardId: Int) -> String { "/like/\(boardId)/count" }
+    }
+
+    enum Dislike {
+        static func dislike(_ boardId: Int) -> String { "/dislike/\(boardId)" }
+        static func cancel(_ boardId: Int) -> String { "/dislike/\(boardId)" }
+        static func count(_ boardId: Int) -> String { "/dislike/\(boardId)/count" }
+    }
+
+    enum Bookmark {
+        static func add(_ boardId: Int) -> String { "/bookmark/\(boardId)" }
+        static func cancel(_ boardId: Int) -> String { "/bookmark/\(boardId)" }
+        static func count(_ boardId: Int) -> String { "/bookmark/\(boardId)/count" }
+    }
+
+    enum Report {
+        static func submit(_ boardId: Int) -> String { "/report/\(boardId)" }
+    }
+
+    enum PreferredGenre {
+        static let select = "/preferredGenres"
+    }
+
+    enum Auth {
+        static let register = "/register"
+        static let login = "/login"
+        static func checkNickname(_ nickname: String) -> String { "/checknickname/\(nickname)" }
+        static func checkEmail(_ email: String) -> String { "/checkemail/\(email)" }
+    }
+
+    enum GoogleAuth {
+        static let redirect = "/api/auth/google"
+        static let success = "/api/auth/google/success"
+        static let loginSuccess = "/api/auth/google/login/success"
+        static let callback = "/api/auth/google/callback"
+        static let register = "/api/auth/google/register"
+        static let appLogin = "/api/auth/google/app-login"
+    }
+
+    enum NaverAuth {
+        static let redirect = "/api/auth/naver"
+        static let success = "/api/auth/naver/success"
+        static let loginSuccess = "/api/auth/naver/login/success"
+        static let callback = "/api/auth/naver/callback"
+        static let register = "/api/auth/naver/register"
+        static let appLogin = "/api/auth/naver/app-login"
+    }
+
+    enum KakaoAuth {
+        static let redirect = "/api/auth/kakao"
+        static let success = "/api/auth/kakao/success"
+        static let loginSuccess = "/api/auth/kakao/login/success"
+        static let callback = "/api/auth/kakao/callback"
+        static let register = "/api/auth/kakao/register"
+        static let appLogin = "/api/auth/kakao/app-login"
+    }
+}
+
+enum HTTPMethod: String {
+    case GET, POST, PUT, DELETE
+}
+

--- a/CineHive/CineHive/Network/NetworkManager.swift
+++ b/CineHive/CineHive/Network/NetworkManager.swift
@@ -36,51 +36,50 @@ enum NetworkError: Error, LocalizedError {
 
 final class NetworkManager {
     static let shared = NetworkManager()
-    static let baseURL: String = "http://localhost:8081"
-
+    
     private init() { }
-
+    
     func fetch<T: Decodable>(endpoint: String, queryItems: [URLQueryItem] = []) async throws -> T {
-        guard var components = URLComponents(string: "\(NetworkManager.baseURL)\(endpoint)") else {
+        guard var components = URLComponents(string: "\(EndPoint.baseURL)\(endpoint)") else {
             Logger.log(.error, category: Logger.networking, message: "잘못된 URL: \(endpoint)")
             throw NetworkError.invalidURL
         }
-
+        
         if !queryItems.isEmpty {
             components.queryItems = queryItems
         }
-
+        
         guard let url = components.url else {
             Logger.log(.error, category: Logger.networking, message: "URL 변환 실패: \(components.string ?? "N/A")")
             throw NetworkError.invalidURL
         }
-
+        
         Logger.log(.info, category: Logger.networking, message: "요청 URL: \(url.absoluteString)")
-
+        
         var request = URLRequest(url: url)
-        request.httpMethod = "GET"
+        request.httpMethod = HTTPMethod.GET.rawValue
         request.timeoutInterval = 10
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-
+        
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
-
+            
             guard let httpResponse = response as? HTTPURLResponse else {
                 throw NetworkError.badResponse(statusCode: 0)
             }
-
+            
             Logger.log(.info, category: Logger.networking, message: "서버 응답 코드: \(httpResponse.statusCode)")
-
+            
             guard (200...299).contains(httpResponse.statusCode) else {
                 throw NetworkError.badResponse(statusCode: httpResponse.statusCode)
             }
-
+            
             let decoder = JSONDecoder()
             decoder.keyDecodingStrategy = .useDefaultKeys
             decoder.dateDecodingStrategy = .iso8601
             
             Logger.log(.info, category: Logger.networking, message: "서버 응답 바디: \(String(data: data, encoding: .utf8) ?? "응답 없음")")
-
+            
             return try decoder.decode(T.self, from: data)
         } catch let decodingError as DecodingError {
             Logger.log(.error, category: Logger.networking, message: "JSON 디코딩 오류: \(decodingError.localizedDescription)")
@@ -93,12 +92,12 @@ final class NetworkManager {
     
     // 공통 POST 요청 함수
     func post<T: Decodable, U: Encodable>(endpoint: String, body: U) async throws -> T {
-        guard let url = URL(string: "\(NetworkManager.baseURL)\(endpoint)") else {
+        guard let url = URL(string: "\(EndPoint.baseURL)\(endpoint)") else {
             throw NetworkError.invalidURL
         }
         
         var request = URLRequest(url: url)
-        request.httpMethod = "POST"
+        request.httpMethod = HTTPMethod.POST.rawValue
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         
         // Encodable 데이터 -> JSON 형식 변환
@@ -141,12 +140,12 @@ final class NetworkManager {
     
     // DELETE 요청 함수
     func delete(endpoint: String) async throws {
-        guard let url = URL(string: "\(NetworkManager.baseURL)\(endpoint)") else {
+        guard let url = URL(string: "\(EndPoint.baseURL)\(endpoint)") else {
             throw NetworkError.invalidURL
         }
         
         var request = URLRequest(url: url)
-        request.httpMethod = "DELETE"
+        request.httpMethod = HTTPMethod.DELETE.rawValue
         
         do {
             let (_, response) = try await URLSession.shared.data(for: request)
@@ -168,12 +167,12 @@ final class NetworkManager {
     
     // PUT 요청 함수
     func put<T: Decodable, U: Encodable>(endpoint: String, body: U) async throws -> T {
-        guard let url = URL(string: "\(NetworkManager.baseURL)\(endpoint)") else {
+        guard let url = URL(string: "\(EndPoint.baseURL)\(endpoint)") else {
             throw NetworkError.invalidURL
         }
         
         var request = URLRequest(url: url)
-        request.httpMethod = "PUT"
+        request.httpMethod = HTTPMethod.PUT.rawValue
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         
         // Encodable 데이터 -> JSON 형식 변환


### PR DESCRIPTION
## 작업한 내용  
- EndPoint.swift 파일 추가  
  - 전체 API 경로를 통합 관리할 수 있도록 EndPoint enum으로 구성  
  - 각 도메인별로 정리 (Movie, Board, Comment, Auth, Like 등)  
  - 동적 경로 생성을 위한 함수형 경로도 추가 (e.g. detail(id:), delete(boardId:))  

- NetworkManager.swift 수정  
  - 기존의 baseURL을 `EndPoint.baseURL`로 통합하여 일관성 있게 적용  
  - HTTPMethod enum 도입하여 명시적인 메서드 사용 (GET, POST 등)  
  - fetch / post / put / delete 메서드의 URL 생성부 전체 수정  
  - 요청 메서드에 HTTPMethod.rawValue 사용  
  - 코드 중복 제거 및 유지보수성 향상  

- 기존 사용하던 `NetworkManager.baseURL` 관련 코드 제거  

## PR Point  
- baseURL 및 endpoint 구성이 명확히 분리되어 있는지  
- API 호출 시 동적 경로 생성이 잘 작동하는지 (`detail(id:)`, `register(_: Int)` 등)  
- HTTPMethod를 사용한 요청 방식이 의도대로 적용되는지  
- 기존에 작성한 API 서비스들(BoardService, CommentService 등)이 정상 동작하는지  

## 향후 작업 예정 사항  
> 아래 항목은 해당 PR 이후에 처리될 예정입니다. 각 항목은 별도 이슈로 생성되었습니다.

- [ ] [#20](https://github.com/Cine-Hive/CineHive-App/issues/20) 서버 API 버그 수정 후 전체 네트워크 로직 리팩토링  
- [ ] [#21](https://github.com/Cine-Hive/CineHive-App/issues/21) 인증 헤더, 토큰 포함 API 요청 방식 도입  
- [ ] [#22](https://github.com/Cine-Hive/CineHive-App/issues/22) 서버 통신 실패 시 재시도 및 사용자 피드백 개선  
- [ ] [#23](https://github.com/Cine-Hive/CineHive-App/issues/23) 로그 레벨 분리 및 테스트 환경 로그 비활성화  
- [ ] [#24](https://github.com/Cine-Hive/CineHive-App/issues/24) 오프라인 상태 감지 기능 적용  
- [ ] [#25](https://github.com/Cine-Hive/CineHive-App/issues/25) Service 레벨 코드의 네트워크 로직 리팩토링

## 스크린샷  
N/A