### PR TITLE
[Refactor/network-monitoring]: Network 연결 상태 모니터링 기능 추가

### DIFF
--- a/CineHive/CineHive/Network/NetworkManager.swift
+++ b/CineHive/CineHive/Network/NetworkManager.swift
@@ -78,7 +78,7 @@ final class NetworkManager {
             decoder.keyDecodingStrategy = .useDefaultKeys
             decoder.dateDecodingStrategy = .iso8601
             
-            Logger.log(.info, category: Logger.networking, message: "서버 응답 바디: \(String(data: data, encoding: .utf8) ?? "응답 없음")")
+            //Logger.log(.info, category: Logger.networking, message: "서버 응답 바디: \(String(data: data, encoding: .utf8) ?? "응답 없음")")
             
             return try decoder.decode(T.self, from: data)
         } catch let decodingError as DecodingError {

--- a/CineHive/CineHive/Network/NetworkMonitor.swift
+++ b/CineHive/CineHive/Network/NetworkMonitor.swift
@@ -17,15 +17,24 @@ final class NetworkMonitor {
     private let queue = DispatchQueue(label: "NetworkMonitorQueue")
 
     var isConnected: Bool = true
+    private var streamContinuation: AsyncStream<Bool>.Continuation?
 
     private init() {
         monitor.pathUpdateHandler = { [weak self] path in
             guard let self else { return }
             Task { @MainActor in
                 self.isConnected = (path.status == .satisfied)
+                self.streamContinuation?.yield(self.isConnected)
                 print("네트워크 상태: \(self.isConnected ? "연결됨" : "끊김")")
             }
         }
         monitor.start(queue: queue)
+    }
+
+    func connectionStream() -> AsyncStream<Bool> {
+        AsyncStream { continuation in
+            self.streamContinuation = continuation
+            continuation.yield(self.isConnected) // 초기값 전송
+        }
     }
 }

--- a/CineHive/CineHive/Network/NetworkMonitor.swift
+++ b/CineHive/CineHive/Network/NetworkMonitor.swift
@@ -1,0 +1,31 @@
+//
+//  NetworkMonitor.swift
+//  CineHive
+//
+//  Created by 이종민 on 3/30/25.
+//
+
+import Foundation
+import Network
+import Observation
+
+@Observable
+final class NetworkMonitor {
+    static let shared = NetworkMonitor()
+
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue(label: "NetworkMonitorQueue")
+
+    var isConnected: Bool = true
+
+    private init() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard let self else { return }
+            Task { @MainActor in
+                self.isConnected = (path.status == .satisfied)
+                print("네트워크 상태: \(self.isConnected ? "연결됨" : "끊김")")
+            }
+        }
+        monitor.start(queue: queue)
+    }
+}

--- a/CineHive/CineHive/ViewModels/MainTabViewModel.swift
+++ b/CineHive/CineHive/ViewModels/MainTabViewModel.swift
@@ -1,0 +1,32 @@
+//
+//  MainTabViewModel.swift
+//  CineHive
+//
+//  Created by 이종민 on 3/30/25.
+//
+
+import Foundation
+import Observation
+
+@Observable
+final class MainTabViewModel {
+    var isNetworkConnected: Bool = true
+    var showNetworkToast: Bool = false
+
+    private let monitor = NetworkMonitor.shared
+
+    init() {
+        observeNetwork()
+    }
+
+    private func observeNetwork() {
+        Task {
+            for await connection in monitor.connectionStream() {
+                self.isNetworkConnected = connection
+                if connection == false {
+                    self.showNetworkToast = true
+                }
+            }
+        }
+    }
+}

--- a/CineHive/CineHive/ViewModels/MainTabViewModel.swift
+++ b/CineHive/CineHive/ViewModels/MainTabViewModel.swift
@@ -29,4 +29,13 @@ final class MainTabViewModel {
             }
         }
     }
+    
+    func retryNetworkCheck() {
+            Task { @MainActor in
+                self.isNetworkConnected = monitor.isConnected
+                if monitor.isConnected {
+                    self.showNetworkToast = false
+                }
+            }
+        }
 }

--- a/CineHive/CineHive/Views/Error/ErrorToastView.swift
+++ b/CineHive/CineHive/Views/Error/ErrorToastView.swift
@@ -10,25 +10,49 @@ import SwiftUI
 struct ErrorToastView: View {
     let message: String
     let accentColor: Color
-    
-    init(message: String, accentColor: Color = .red) {
+    let iconName: String
+    let actionTitle: String?
+    let action: (() -> Void)?
+
+    init(
+        message: String,
+        accentColor: Color = .red,
+        iconName: String = "exclamationmark.triangle.fill",
+        actionTitle: String? = nil,
+        action: (() -> Void)? = nil
+    ) {
         self.message = message
         self.accentColor = accentColor
+        self.iconName = iconName
+        self.actionTitle = actionTitle
+        self.action = action
     }
-    
+
     var body: some View {
         HStack(spacing: 12) {
-            Image(systemName: "exclamationmark.triangle.fill")
+            Image(systemName: iconName)
                 .foregroundColor(.white)
                 .font(.system(size: 18))
-            
+
             Text(message)
                 .font(.system(size: 15, weight: .medium))
                 .foregroundColor(.white)
                 .multilineTextAlignment(.leading)
                 .lineLimit(2)
-            
+
             Spacer()
+
+            if let actionTitle, let action {
+                Button(actionTitle) {
+                    action()
+                }
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(.white)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(.white.opacity(0.2))
+                .clipShape(Capsule())
+            }
         }
         .padding(.vertical, 12)
         .padding(.horizontal, 16)
@@ -43,33 +67,44 @@ struct ErrorToastView: View {
 }
 
 extension View {
-    func errorToast(message: String?, isPresented: Binding<Bool>, duration: Double = 2.5, accentColor: Color = .red) -> some View {
+    func errorToast(
+        message: String?,
+        isPresented: Binding<Bool>,
+        duration: Double = 2.5,
+        accentColor: Color = .red,
+        iconName: String = "exclamationmark.triangle.fill",
+        actionTitle: String? = nil,
+        action: (() -> Void)? = nil
+    ) -> some View {
         ZStack {
             self
             if isPresented.wrappedValue, let message = message {
                 VStack {
                     Spacer()
-                    ErrorToastView(message: message, accentColor: accentColor)
-                        .transition(.move(edge: .bottom).combined(with: .opacity))
-                        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isPresented.wrappedValue)
-                        .gesture(
-                            DragGesture()
-                                .onEnded { gesture in
-                                    if gesture.translation.height > 20 {
-                                        withAnimation {
-                                            isPresented.wrappedValue = false
-                                        }
+                    ErrorToastView(
+                        message: message,
+                        accentColor: accentColor,
+                        iconName: iconName,
+                        actionTitle: actionTitle,
+                        action: action
+                    )
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isPresented.wrappedValue)
+                    .gesture(
+                        DragGesture()
+                            .onEnded { gesture in
+                                if gesture.translation.height > 20 {
+                                    withAnimation {
+                                        isPresented.wrappedValue = false
                                     }
                                 }
-                        )
+                            }
+                    )
                 }
                 .transition(.identity)
                 .onAppear {
-                    // Haptic feedback when error appears
                     let generator = UINotificationFeedbackGenerator()
                     generator.notificationOccurred(.error)
-                    
-                    // Auto dismiss after specified duration
                     DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
                         withAnimation(.easeOut) {
                             isPresented.wrappedValue = false

--- a/CineHive/CineHive/Views/Error/ErrorToastView.swift
+++ b/CineHive/CineHive/Views/Error/ErrorToastView.swift
@@ -62,7 +62,7 @@ struct ErrorToastView: View {
                 .shadow(color: Color.black.opacity(0.2), radius: 5, x: 0, y: 2)
         )
         .padding(.horizontal, 20)
-        .padding(.bottom, 20)
+        .padding(.bottom, 50)
     }
 }
 

--- a/CineHive/CineHive/Views/TabBar/MainTabView.swift
+++ b/CineHive/CineHive/Views/TabBar/MainTabView.swift
@@ -12,8 +12,7 @@ struct MainTabView: View {
     @State private var previousTab = 0
     @State private var tabBarManager = TabBarManager.shared
 
-    @Bindable var networkMonitor = NetworkMonitor.shared
-    @State private var showNetworkError = false
+    @State private var viewModel = MainTabViewModel()
 
     var body: some View {
         NavigationStack {
@@ -22,30 +21,18 @@ struct MainTabView: View {
 
                 ZStack {
                     switch selectedTab {
-                    case 0:
-                        HomeTabView()
-                            .transition(.opacity)
-                    case 1:
-                        ExploreTabView()
-                            .transition(.opacity)
-                    case 2:
-                        CommunityTabView()
-                            .transition(.opacity)
+                    case 0: HomeTabView()
+                    case 1: ExploreTabView()
+                    case 2: CommunityTabView()
                     case 3:
-                        PreparingView(
-                            type: "프로필",
-                            actionTitle: "확인"
-                        ) {
+                        PreparingView(type: "프로필", actionTitle: "확인") {
                             selectedTab = previousTab
                         }
-                        .transition(.opacity)
-                    default:
-                        EmptyView()
+                    default: EmptyView()
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .animation(.easeInOut(duration: 0.2), value: selectedTab)
-                .background(CHColors.backgroundColor)
 
                 CustomTabBar(selectedTab: $selectedTab, items: TabItem.items)
                     .offset(y: tabBarManager.isVisible ? 0 : 100)
@@ -53,20 +40,14 @@ struct MainTabView: View {
                     .ignoresSafeArea(.all, edges: .bottom)
                     .padding(.bottom, -30)
             }
-            .onChange(of: networkMonitor.isConnected) { _, isConnected in
-                if !isConnected {
-                    showNetworkError = true
-                }
-            }
             .errorToast(
                 message: "인터넷 연결이 끊겼습니다",
-                isPresented: $showNetworkError,
+                isPresented: $viewModel.showNetworkToast,
                 accentColor: .red,
                 iconName: "wifi.slash",
                 actionTitle: "재시도",
                 action: {
-                    // 재시도 로직: 필요한 경우 네트워크 요청 트리거
-                    print("재시도 버튼 눌림")
+                    print("재시도")
                 }
             )
         }

--- a/CineHive/CineHive/Views/TabBar/MainTabView.swift
+++ b/CineHive/CineHive/Views/TabBar/MainTabView.swift
@@ -11,11 +11,15 @@ struct MainTabView: View {
     @State private var selectedTab = 0
     @State private var previousTab = 0
     @State private var tabBarManager = TabBarManager.shared
-    
+
+    @Bindable var networkMonitor = NetworkMonitor.shared
+    @State private var showNetworkError = false
+
     var body: some View {
-        NavigationStack{
+        NavigationStack {
             ZStack(alignment: .bottom) {
                 CHColors.backgroundColor.edgesIgnoringSafeArea(.all)
+
                 ZStack {
                     switch selectedTab {
                     case 0:
@@ -26,9 +30,8 @@ struct MainTabView: View {
                             .transition(.opacity)
                     case 2:
                         CommunityTabView()
-                        .transition(.opacity)
+                            .transition(.opacity)
                     case 3:
-                        //ProfileTabView()
                         PreparingView(
                             type: "프로필",
                             actionTitle: "확인"
@@ -43,13 +46,29 @@ struct MainTabView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .animation(.easeInOut(duration: 0.2), value: selectedTab)
                 .background(CHColors.backgroundColor)
-                
+
                 CustomTabBar(selectedTab: $selectedTab, items: TabItem.items)
                     .offset(y: tabBarManager.isVisible ? 0 : 100)
                     .animation(.spring(response: 0.3), value: tabBarManager.isVisible)
                     .ignoresSafeArea(.all, edges: .bottom)
                     .padding(.bottom, -30)
             }
+            .onChange(of: networkMonitor.isConnected) { _, isConnected in
+                if !isConnected {
+                    showNetworkError = true
+                }
+            }
+            .errorToast(
+                message: "인터넷 연결이 끊겼습니다",
+                isPresented: $showNetworkError,
+                accentColor: .red,
+                iconName: "wifi.slash",
+                actionTitle: "재시도",
+                action: {
+                    // 재시도 로직: 필요한 경우 네트워크 요청 트리거
+                    print("재시도 버튼 눌림")
+                }
+            )
         }
     }
 }
@@ -57,3 +76,4 @@ struct MainTabView: View {
 #Preview {
     MainTabView()
 }
+

--- a/CineHive/CineHive/Views/TabBar/MainTabView.swift
+++ b/CineHive/CineHive/Views/TabBar/MainTabView.swift
@@ -47,7 +47,7 @@ struct MainTabView: View {
                 iconName: "wifi.slash",
                 actionTitle: "재시도",
                 action: {
-                    print("재시도")
+                    viewModel.retryNetworkCheck()
                 }
             )
         }


### PR DESCRIPTION
## 작업한 내용
- NetworkManager에서 baseURL 및 HTTPMethod를 EndPoint 기반으로 통일
  - 코드 중복 제거 및 오타 위험 감소

- NWPathMonitor를 활용한 NetworkMonitor 클래스 구현
  - 연결 상태 변화 감지 시 MainTabViewModel에 전달
  - 연결 끊김 시 토스트 메시지 출력하도록 구성

- ErrorToastView 개선
  - 아이콘, 버튼 텍스트, 재시도 액션 등 커스터마이징 가능
  - 드래그로 dismiss 가능하게 UX 향상

- MainTabView에서 네트워크 끊김 시 사용자에게 알리고, 재시도 가능하도록 반영

## PR Point
- NetworkMonitor와 ViewModel 사이의 상태 흐름이 자연스럽고 명확한지
- 연결 끊김 시 토스트가 잘 출력되고, 재시도 버튼 동작이 의도대로 되는지
- NetworkManager 내부 로직 변경에 따른 기존 fetch/post/put/delete 사용에 문제 없는지

## 스크린샷
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/dc4acfe5-676c-45fa-a72a-027b836b6039" width="200"><br>
      <p>인터넷 연결 끊김 시 토스트 메시지 표시</p>
    </td>
  </tr>
</table>


