### PR TITLE
[Feature/social-kakao]: 카카오 소셜 로그인 기능 구현

### DIFF
--- a/CineHive/CineHive.xcodeproj/project.pbxproj
+++ b/CineHive/CineHive.xcodeproj/project.pbxproj
@@ -17,9 +17,22 @@
 		B3C0C1512991CDACD0534E14 /* Pods-CineHive.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CineHive.release.xcconfig"; path = "Target Support Files/Pods-CineHive/Pods-CineHive.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		8C6454AC2DA755BF00B71992 /* Exceptions for "CineHive" folder in "CineHive" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 9BF395F22D61F29E00044A64 /* CineHive */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		9BF395F52D61F29E00044A64 /* CineHive */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				8C6454AC2DA755BF00B71992 /* Exceptions for "CineHive" folder in "CineHive" target */,
+			);
 			path = CineHive;
 			sourceTree = "<group>";
 		};
@@ -172,9 +185,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-CineHive/Pods-CineHive-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-CineHive/Pods-CineHive-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -324,6 +341,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"CineHive/Core/Utils/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = CineHive/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -354,6 +372,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"CineHive/Core/Utils/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = CineHive/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/CineHive/CineHive/App/CineHiveApp.swift
+++ b/CineHive/CineHive/App/CineHiveApp.swift
@@ -6,15 +6,30 @@
 //
 
 import SwiftUI
+import KakaoSDKCommon
+import KakaoSDKAuth
 
 @main
 struct CineHiveApp: App {
     @State private var userState = UserState.shared
     
+    init() {
+        // Kakao SDK 초기화
+        if let kakaoAppKey = Bundle.main.object(forInfoDictionaryKey: "KAKAO_NATIVE_APP_KEY") as? String {
+            KakaoSDK.initSDK(appKey: kakaoAppKey)
+            print("Kakao App Key: \(kakaoAppKey)")
+        }
+    }
+    
     var body: some Scene {
         WindowGroup {
-            ContentView()
-                .environment(userState)
+            // onOpenURL()을 사용해 커스텀 URL 스킴 처리
+            ContentView().onOpenURL(perform: { url in
+                if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                    AuthController.handleOpenUrl(url: url)
+                }
+            })
+            .environment(userState)
         }
     }
 }

--- a/CineHive/CineHive/App/CineHiveApp.swift
+++ b/CineHive/CineHive/App/CineHiveApp.swift
@@ -17,7 +17,6 @@ struct CineHiveApp: App {
         // Kakao SDK 초기화
         if let kakaoAppKey = Bundle.main.object(forInfoDictionaryKey: "KAKAO_NATIVE_APP_KEY") as? String {
             KakaoSDK.initSDK(appKey: kakaoAppKey)
-            print("Kakao App Key: \(kakaoAppKey)")
         }
     }
     

--- a/CineHive/CineHive/Core/Models/User.swift
+++ b/CineHive/CineHive/Core/Models/User.swift
@@ -54,9 +54,21 @@ struct LoginUser: Codable {
 }
 
 struct LoginResponse: Codable {
-    let message: String
+    let message: String?
     let user: UserData
     let token: String
+}
+
+struct SocialLoginResponse: Codable, ResponseWithStatusCode {
+    var statusCode: Int?
+    let user: UserData
+    let token: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case statusCode
+        case user
+        case token
+    }
 }
 
 struct UserData: Codable {
@@ -65,6 +77,14 @@ struct UserData: Codable {
     let nickname: String
     let email: String
     let gender: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case email = "memEmail"
+        case name = "memName"
+        case genres = "genres"
+        case nickname = "memNickname"
+        case gender = "memSex"
+    }
 }
 
 struct SignUpResponse: Codable {

--- a/CineHive/CineHive/Core/Models/User.swift
+++ b/CineHive/CineHive/Core/Models/User.swift
@@ -59,7 +59,7 @@ struct LoginResponse: Codable {
     let token: String
 }
 
-struct SocialLoginResponse: Codable, ResponseWithStatusCode {
+struct SocialLoginResponse: Codable {
     var statusCode: Int?
     let user: UserData
     let token: String?

--- a/CineHive/CineHive/Core/Network/EndPoint.swift
+++ b/CineHive/CineHive/Core/Network/EndPoint.swift
@@ -7,8 +7,29 @@
 
 import Foundation
 
+// 서버 환경별 baseURL 설정 구조
+enum ServerEnvironment {
+    // 개발자
+    case development
+    // 내부 테스트
+    case staging
+    // 일반 사용자
+    case production
+
+    var baseURL: String {
+        switch self {
+        case .development:
+            return "http://localhost:8081"
+        case .staging:
+            return "https://staging.api.cinehive.com"
+        case .production:
+            return "https://api.cinehive.com"
+        }
+    }
+}
+
 enum EndPoint {
-    static let baseURL = "http://localhost:8081"
+    static let baseURL = ServerEnvironment.development.baseURL
 
     enum NowPlaying {
         static let get = "/now_playing"

--- a/CineHive/CineHive/Core/Network/NetworkManager.swift
+++ b/CineHive/CineHive/Core/Network/NetworkManager.swift
@@ -7,9 +7,6 @@
 
 import Foundation
 import OSLog
-protocol ResponseWithStatusCode {
-    var statusCode: Int? { get set }
-}
 
 enum NetworkError: Error, LocalizedError {
     case invalidURL
@@ -136,21 +133,11 @@ final class NetworkManager {
             }
             
             do {
-                var decoded = try JSONDecoder().decode(T.self, from: data)
-                
-                // statusCode 주입
-                if var responseWithStatusCode = decoded as? ResponseWithStatusCode {
-                    responseWithStatusCode.statusCode = httpResponse.statusCode
-                    return responseWithStatusCode as! T
-                }
-                
-                return decoded
+                return try decodeResponse(data: data, response: httpResponse)
             } catch let decodingError as DecodingError {
-
                 if let responseString = String(data: data, encoding: .utf8) {
                     Logger.log(.error, category: Logger.networking, message: "서버 응답 원본 데이터: \(responseString)")
                 }
-
                 throw NetworkError.decodingError(decodingError)
             }
         } catch {
@@ -353,20 +340,12 @@ final class NetworkManager {
             }
             
             do {
-                var decoded = try JSONDecoder().decode(T.self, from: data)
-                
-                // 상태 코드 주입
-                if var responseWithStatusCode = decoded as? ResponseWithStatusCode {
-                    responseWithStatusCode.statusCode = httpResponse.statusCode
-                    return responseWithStatusCode as! T
-                }
-                
-                return decoded
-            } catch {
+                return try decodeResponse(data: data, response: httpResponse)
+            } catch let decodingError as DecodingError {
                 if let responseString = String(data: data, encoding: .utf8) {
                     Logger.log(.error, category: Logger.networking, message: "서버 응답 원본 데이터: \(responseString)")
                 }
-                throw NetworkError.decodingError(error)
+                throw NetworkError.decodingError(decodingError)
             }
         } catch {
             if let networkError = error as? NetworkError {

--- a/CineHive/CineHive/Core/Network/NetworkManager.swift
+++ b/CineHive/CineHive/Core/Network/NetworkManager.swift
@@ -7,6 +7,9 @@
 
 import Foundation
 import OSLog
+protocol ResponseWithStatusCode {
+    var statusCode: Int? { get set }
+}
 
 enum NetworkError: Error, LocalizedError {
     case invalidURL
@@ -133,12 +136,22 @@ final class NetworkManager {
             }
             
             do {
-                return try JSONDecoder().decode(T.self, from: data)
-            } catch {
+                var decoded = try JSONDecoder().decode(T.self, from: data)
+                
+                // statusCode 주입
+                if var responseWithStatusCode = decoded as? ResponseWithStatusCode {
+                    responseWithStatusCode.statusCode = httpResponse.statusCode
+                    return responseWithStatusCode as! T
+                }
+                
+                return decoded
+            } catch let decodingError as DecodingError {
+
                 if let responseString = String(data: data, encoding: .utf8) {
                     Logger.log(.error, category: Logger.networking, message: "서버 응답 원본 데이터: \(responseString)")
                 }
-                throw NetworkError.decodingError(error)
+
+                throw NetworkError.decodingError(decodingError)
             }
         } catch {
             if let networkError = error as? NetworkError {
@@ -340,7 +353,15 @@ final class NetworkManager {
             }
             
             do {
-                return try JSONDecoder().decode(T.self, from: data)
+                var decoded = try JSONDecoder().decode(T.self, from: data)
+                
+                // 상태 코드 주입
+                if var responseWithStatusCode = decoded as? ResponseWithStatusCode {
+                    responseWithStatusCode.statusCode = httpResponse.statusCode
+                    return responseWithStatusCode as! T
+                }
+                
+                return decoded
             } catch {
                 if let responseString = String(data: data, encoding: .utf8) {
                     Logger.log(.error, category: Logger.networking, message: "서버 응답 원본 데이터: \(responseString)")

--- a/CineHive/CineHive/Core/Network/ResponseWithStatusCode.swift
+++ b/CineHive/CineHive/Core/Network/ResponseWithStatusCode.swift
@@ -1,0 +1,32 @@
+//
+//  ResponseWithStatusCode.swift
+//  CineHive
+//
+//  Created by 존진 on 5/6/25.
+//
+
+import Foundation
+
+protocol ResponseWithStatusCode {
+    var statusCode: Int { get set }
+}
+
+extension ResponseWithStatusCode {
+    mutating func injectStatusCode(_ code: Int) {
+        self.statusCode = code
+    }
+}
+
+func decodeResponse<T: Decodable>(data: Data, response: HTTPURLResponse) throws -> T {
+    let decoded = try JSONDecoder().decode(T.self, from: data)
+
+    if var responseWithCode = decoded as? any ResponseWithStatusCode {
+        responseWithCode.injectStatusCode(response.statusCode)
+
+        if let typedResponse = responseWithCode as? T {
+            return typedResponse
+        }
+    }
+
+    return decoded
+}

--- a/CineHive/CineHive/Core/State/AuthManager.swift
+++ b/CineHive/CineHive/Core/State/AuthManager.swift
@@ -165,4 +165,14 @@ final class AuthManager {
         clearToken()
         clearUser()
     }
+    // MARK: - 디버깅
+
+    /// 키체인에 저장된 토큰 값을 로그로 출력 (디버깅용)
+    func debugPrintToken() {
+        if let token = getToken() {
+            Logger.log(.info, category: Logger.auth, message: "키체인에 저장된 토큰: \(token)")
+        } else {
+            Logger.log(.info, category: Logger.auth, message: "키체인에 저장된 토큰 없음")
+        }
+    }
 }

--- a/CineHive/CineHive/Core/State/UserState.swift
+++ b/CineHive/CineHive/Core/State/UserState.swift
@@ -129,9 +129,12 @@ final class UserState {
             }
             
             // 응답 정보 유효성 확인
-            guard ((response.token?.isEmpty) == nil), response.user.email.count > 0, response.user.nickname.count > 0 else {
-                self.errorMessage = "서버에서 올바른 사용자 정보를 받지 못했습니다"
-                self.isLoading = false
+            guard
+                let token = response.token?.trimmingCharacters(in: .whitespacesAndNewlines),
+                !token.isEmpty,
+                response.user.email.count > 0,
+                response.user.nickname.count > 0
+            else {
                 Logger.log(.error, category: Logger.auth, message: "소셜 로그인 응답 데이터 불완전: \(response)")
                 return false
             }

--- a/CineHive/CineHive/Core/State/UserState.swift
+++ b/CineHive/CineHive/Core/State/UserState.swift
@@ -25,6 +25,10 @@ final class UserState {
     // 게스트 모드 상태
     var isGuestMode: Bool = false
     
+    // 네비게이션 상태
+    var shouldNavigateToMain: Bool = false
+    var shouldNavigateToSignUp: Bool = false
+    
     private init() {
         // 앱 실행 시 저장된 토큰과 사용자 정보 확인
         self.isLoggedIn = AuthManager.shared.isLoggedIn
@@ -147,6 +151,15 @@ final class UserState {
             self.currentUser = response.user
             self.isLoggedIn = true
             self.isLoading = false
+            
+            switch response.statusCode {
+            case 200:
+                self.shouldNavigateToMain = true
+            case 201:
+                self.shouldNavigateToSignUp = true
+            default:
+                Logger.log(.error, category: Logger.auth, message: "\(provider.rawValue) 로그인 응답 상태코드: \(String(describing: response.statusCode))")
+            }
             
             Logger.log(.info, category: Logger.auth, message: "\(provider.rawValue) 로그인 성공: \(response.user.email)")
             return true

--- a/CineHive/CineHive/Core/State/UserState.swift
+++ b/CineHive/CineHive/Core/State/UserState.swift
@@ -110,7 +110,7 @@ final class UserState {
         errorMessage = nil
         
         do {
-            let response: LoginResponse
+            let response: SocialLoginResponse
             
             // 소셜 로그인 제공자에 따라 적절한 API 호출
             switch provider {

--- a/CineHive/CineHive/Core/State/UserState.swift
+++ b/CineHive/CineHive/Core/State/UserState.swift
@@ -30,16 +30,17 @@ final class UserState {
         self.isLoggedIn = AuthManager.shared.isLoggedIn
         if isLoggedIn {
             // 사용자 정보 복원 시도
-            if let savedUser = AuthManager.shared.getUser() {
-                self.currentUser = savedUser
-                let userInfo = "이메일: \(savedUser.email), 닉네임: \(savedUser.nickname)"
-                Logger.log(.info, category: Logger.auth, message: "기존 사용자 세션 복원 성공: \(userInfo)")
-            } else {
-                // 토큰은 있지만 사용자 정보가 없는 경우
-                Logger.log(.error, category: Logger.auth, message: "토큰은 있으나 사용자 정보 없음. 사용자 세션 초기화")
-                AuthManager.shared.clearToken() // 불완전한 상태이므로 토큰도 제거
-                self.isLoggedIn = false
-            }
+        if AuthManager.shared.getUser() != nil {
+            let savedUser = AuthManager.shared.getUser()!
+            self.currentUser = savedUser
+            let userInfo = "이메일: \(savedUser.email), 닉네임: \(savedUser.nickname)"
+            Logger.log(.info, category: Logger.auth, message: "기존 사용자 세션 복원 성공: \(userInfo)")
+        } else {
+            // 토큰은 있지만 사용자 정보가 없는 경우
+            Logger.log(.error, category: Logger.auth, message: "토큰은 있으나 사용자 정보 없음. 사용자 세션 초기화")
+            AuthManager.shared.clearToken() // 불완전한 상태이므로 토큰도 제거
+            self.isLoggedIn = false
+        }
         }
     }
     
@@ -128,7 +129,7 @@ final class UserState {
             }
             
             // 응답 정보 유효성 확인
-            guard !response.token.isEmpty, response.user.email.count > 0, response.user.nickname.count > 0 else {
+            guard ((response.token?.isEmpty) == nil), response.user.email.count > 0, response.user.nickname.count > 0 else {
                 self.errorMessage = "서버에서 올바른 사용자 정보를 받지 못했습니다"
                 self.isLoading = false
                 Logger.log(.error, category: Logger.auth, message: "소셜 로그인 응답 데이터 불완전: \(response)")
@@ -136,7 +137,7 @@ final class UserState {
             }
             
             // JWT 토큰과 사용자 정보 저장
-            AuthManager.shared.saveToken(response.token)
+            AuthManager.shared.saveToken(response.token ?? "nil")
             AuthManager.shared.saveUser(response.user)
             
             // 상태 업데이트

--- a/CineHive/CineHive/Core/State/UserState.swift
+++ b/CineHive/CineHive/Core/State/UserState.swift
@@ -87,6 +87,8 @@ final class UserState {
             // JWT 토큰과 사용자 정보 저장
             AuthManager.shared.saveToken(response.token)
             AuthManager.shared.saveUser(response.user)
+            // 키체인에 저장된 토큰 값 확인
+            AuthManager.shared.debugPrintToken()
             
             // 상태 업데이트
             self.currentUser = response.user

--- a/CineHive/CineHive/Core/State/UserState.swift
+++ b/CineHive/CineHive/Core/State/UserState.swift
@@ -131,7 +131,7 @@ final class UserState {
                 // Apple 로그인은 아직 서버 API가 준비되지 않은 것으로 가정
                 self.errorMessage = "Apple 로그인은 아직 지원되지 않습니다"
                 self.isLoading = false
-                return .failure("Apple 로그인은 아직 지원되지 않습니다")
+                return .failure(.environmentMisconfigured(description: "Apple 로그인은 아직 지원되지 않습니다"))
             }
             
             // 상태코드에 따라 분기 처리
@@ -146,7 +146,7 @@ final class UserState {
                 else {
                     Logger.log(.error, category: Logger.auth, message: "소셜 로그인 응답 데이터 불완전 (200): \(response)")
                     self.isLoading = false
-                    return .failure("응답 데이터가 불완전")
+                    return .failure(.decodingFailed(field: "user.email / user.nickname / token", description: "소셜 로그인 응답 필드 누락"))
                 }
                 
                 saveLoginInfo(token: token, user: response.user)
@@ -164,7 +164,7 @@ final class UserState {
                 else {
                     Logger.log(.error, category: Logger.auth, message: "소셜 로그인 응답 데이터 불완전 (201): \(response)")
                     self.isLoading = false
-                    return .failure("응답 데이터가 불완전")
+                    return .failure(.decodingFailed(field: "user.email / user.nickname / token", description: "소셜 로그인 응답 필드 누락"))
                 }
                 
                 saveLoginInfo(token: nil, user: response.user)
@@ -177,18 +177,18 @@ final class UserState {
             default:
                 Logger.log(.error, category: Logger.auth, message: "\(provider.rawValue) 로그인 실패: 예상치 못한 상태 코드 \(String(describing: response.statusCode))")
                 self.isLoading = false
-                return .failure("예상치 못한 서버 응답")
+                return .failure(.serverResponse(statusCode: response.statusCode ?? -1, endpoint: "UserService.socialLogin", message: "예상치 못한 상태코드 응답"))
             }
         } catch let error as NetworkError {
             self.errorMessage = error.localizedDescription
             self.isLoading = false
             Logger.log(.error, category: Logger.auth, message: "\(provider.rawValue) 로그인 실패: \(error.localizedDescription)")
-            return .failure("로그인 실패: \(error.localizedDescription)")
+            return .failure(.networkUnavailable(description: error.localizedDescription.isEmpty ? "알 수 없는 네트워크 오류" : error.localizedDescription))
         } catch {
             self.errorMessage = "로그인 중 오류가 발생했습니다"
             self.isLoading = false
             Logger.log(.error, category: Logger.auth, message: "\(provider.rawValue) 로그인 실패: \(error.localizedDescription)")
-            return .failure("로그인 실패: \(error.localizedDescription)")
+            return .failure(.internalError(description: error.localizedDescription.isEmpty ? "예기치 못한 내부 오류" : error.localizedDescription))
         }
     }
     
@@ -317,5 +317,44 @@ enum SocialLoginProvider: String {
 enum SocialLoginResult {
     case successNavigateToMain
     case successNavigateToSignUp
-    case failure(String)
+    case failure(SocialLoginError)
+}
+
+enum SocialLoginError: Error {
+    case networkUnavailable(description: String)
+    case serverResponse(statusCode: Int, endpoint: String, message: String)
+    case decodingFailed(field: String, description: String)
+    case unknown(description: String)
+    
+    // 네트워크 관련
+    case timeout(description: String) // 요청 시간 초과
+    case noInternetConnection // 인터넷 연결 없음
+    case serverUnavailable(description: String) // 서버 응답 없음
+
+    // 시스템 또는 클라이언트 관련
+    case internalError(description: String) // 내부 처리 중 오류
+    case environmentMisconfigured(description: String) // 잘못된 환경 설정
+
+    var message: String {
+        switch self {
+        case .networkUnavailable(let description):
+            return "네트워크에 연결 오류: \(description)"
+        case .serverResponse(let code, let endpoint, let message):
+            return "서버 오류 (상태 코드 \(code), 요청 경로 \(endpoint)): \(message)"
+        case .decodingFailed(let field, let description):
+            return "응답 데이터 처리 실패 (\(field)): \(description)"
+        case .unknown(let description):
+            return "알 수 없는 오류 발생: \(description)"
+        case .timeout(let description):
+            return "요청 시간이 초과: \(description)"
+        case .noInternetConnection:
+            return "인터넷 연결되어 있지 않음"
+        case .serverUnavailable(let description):
+            return "서버 응답하지 않음: \(description)"
+        case .internalError(let description):
+            return "내부 오류 발생: \(description)"
+        case .environmentMisconfigured(let description):
+            return "환경 설정 오류: \(description)"
+        }
+    }
 }

--- a/CineHive/CineHive/Core/State/UserState.swift
+++ b/CineHive/CineHive/Core/State/UserState.swift
@@ -34,17 +34,17 @@ final class UserState {
         self.isLoggedIn = AuthManager.shared.isLoggedIn
         if isLoggedIn {
             // 사용자 정보 복원 시도
-        if AuthManager.shared.getUser() != nil {
-            let savedUser = AuthManager.shared.getUser()!
-            self.currentUser = savedUser
-            let userInfo = "이메일: \(savedUser.email), 닉네임: \(savedUser.nickname)"
-            Logger.log(.info, category: Logger.auth, message: "기존 사용자 세션 복원 성공: \(userInfo)")
-        } else {
-            // 토큰은 있지만 사용자 정보가 없는 경우
-            Logger.log(.error, category: Logger.auth, message: "토큰은 있으나 사용자 정보 없음. 사용자 세션 초기화")
-            AuthManager.shared.clearToken() // 불완전한 상태이므로 토큰도 제거
-            self.isLoggedIn = false
-        }
+            if AuthManager.shared.getUser() != nil {
+                let savedUser = AuthManager.shared.getUser()!
+                self.currentUser = savedUser
+                let userInfo = "이메일: \(savedUser.email), 닉네임: \(savedUser.nickname)"
+                Logger.log(.info, category: Logger.auth, message: "기존 사용자 세션 복원 성공: \(userInfo)")
+            } else {
+                // 토큰은 있지만 사용자 정보가 없는 경우
+                Logger.log(.error, category: Logger.auth, message: "토큰은 있으나 사용자 정보 없음. 사용자 세션 초기화")
+                AuthManager.shared.clearToken() // 불완전한 상태이므로 토큰도 제거
+                self.isLoggedIn = false
+            }
         }
     }
     
@@ -112,7 +112,7 @@ final class UserState {
     
     /// 소셜 로그인 처리
     @MainActor
-    func socialLogin(provider: SocialLoginProvider, token: String) async -> Bool {
+    func socialLogin(provider: SocialLoginProvider, token: String) async -> SocialLoginResult {
         isLoading = true
         errorMessage = nil
         
@@ -131,51 +131,74 @@ final class UserState {
                 // Apple 로그인은 아직 서버 API가 준비되지 않은 것으로 가정
                 self.errorMessage = "Apple 로그인은 아직 지원되지 않습니다"
                 self.isLoading = false
-                return false
+                return .failure("Apple 로그인은 아직 지원되지 않습니다")
             }
             
-            // 응답 정보 유효성 확인
-            guard
-                let token = response.token?.trimmingCharacters(in: .whitespacesAndNewlines),
-                !token.isEmpty,
-                response.user.email.count > 0,
-                response.user.nickname.count > 0
-            else {
-                Logger.log(.error, category: Logger.auth, message: "소셜 로그인 응답 데이터 불완전: \(response)")
-                return false
-            }
-            
-            // JWT 토큰과 사용자 정보 저장
-            AuthManager.shared.saveToken(response.token ?? "nil")
-            AuthManager.shared.saveUser(response.user)
-            
-            // 상태 업데이트
-            self.currentUser = response.user
-            self.isLoggedIn = true
-            self.isLoading = false
-            
+            // 상태코드에 따라 분기 처리
             switch response.statusCode {
             case 200:
+                // 200: 기존 회원 → 로그인 완료 → 토큰 필수
+                guard
+                    let token = response.token?.trimmingCharacters(in: .whitespacesAndNewlines),
+                    !token.isEmpty,
+                    response.user.email.count > 0,
+                    response.user.nickname.count > 0
+                else {
+                    Logger.log(.error, category: Logger.auth, message: "소셜 로그인 응답 데이터 불완전 (200): \(response)")
+                    self.isLoading = false
+                    return .failure("응답 데이터가 불완전")
+                }
+                
+                saveLoginInfo(token: token, user: response.user)
+                self.isLoggedIn = true
                 self.shouldNavigateToMain = true
+                Logger.log(.info, category: Logger.auth, message: "\(provider.rawValue) 로그인 성공 (기존 회원): \(response.user.email)")
+                isLoading = false
+                return .successNavigateToMain
+                
             case 201:
+                // 201: 신규 회원 → 회원가입 페이지로 이동(토큰 없음)
+                guard
+                    response.user.email.count > 0,
+                    response.user.nickname.count > 0
+                else {
+                    Logger.log(.error, category: Logger.auth, message: "소셜 로그인 응답 데이터 불완전 (201): \(response)")
+                    self.isLoading = false
+                    return .failure("응답 데이터가 불완전")
+                }
+                
+                saveLoginInfo(token: nil, user: response.user)
+                self.isLoggedIn = false
                 self.shouldNavigateToSignUp = true
+                Logger.log(.info, category: Logger.auth, message: "\(provider.rawValue) 로그인 성공 (신규 회원): \(response.user.email)")
+                isLoading = false
+                return .successNavigateToSignUp
+                
             default:
-                Logger.log(.error, category: Logger.auth, message: "\(provider.rawValue) 로그인 응답 상태코드: \(String(describing: response.statusCode))")
+                Logger.log(.error, category: Logger.auth, message: "\(provider.rawValue) 로그인 실패: 예상치 못한 상태 코드 \(String(describing: response.statusCode))")
+                self.isLoading = false
+                return .failure("예상치 못한 서버 응답")
             }
-            
-            Logger.log(.info, category: Logger.auth, message: "\(provider.rawValue) 로그인 성공: \(response.user.email)")
-            return true
         } catch let error as NetworkError {
             self.errorMessage = error.localizedDescription
             self.isLoading = false
             Logger.log(.error, category: Logger.auth, message: "\(provider.rawValue) 로그인 실패: \(error.localizedDescription)")
-            return false
+            return .failure("로그인 실패: \(error.localizedDescription)")
         } catch {
             self.errorMessage = "로그인 중 오류가 발생했습니다"
             self.isLoading = false
             Logger.log(.error, category: Logger.auth, message: "\(provider.rawValue) 로그인 실패: \(error.localizedDescription)")
-            return false
+            return .failure("로그인 실패: \(error.localizedDescription)")
         }
+    }
+    
+    private func saveLoginInfo(token: String?, user: UserData) {
+        if let token = token {
+            AuthManager.shared.saveToken(token)
+        }
+        AuthManager.shared.saveUser(user)
+        AuthManager.shared.debugPrintToken()
+        self.currentUser = user
     }
     
     // 로그아웃 처리 (게스트 모드도 종료)
@@ -289,4 +312,10 @@ enum SocialLoginProvider: String {
     case apple = "Apple"
     case kakao = "Kakao"
     case naver = "Naver"
+}
+
+enum SocialLoginResult {
+    case successNavigateToMain
+    case successNavigateToSignUp
+    case failure(String)
 }

--- a/CineHive/CineHive/Features/Auth/View/SocialLogin/KakaoLoginBtnView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SocialLogin/KakaoLoginBtnView.swift
@@ -29,10 +29,10 @@ struct KakaoLoginBtnView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 12))
             })
             
-            .navigationDestination(isPresented: $viewModel.shouldNavigateToMain) {
+            .fullScreenCover(isPresented: $viewModel.shouldNavigateToMain) {
                 MainTabView()
             }
-            .navigationDestination(isPresented: $viewModel.shouldNavigateToSignUp) {
+            .fullScreenCover(isPresented: $viewModel.shouldNavigateToSignUp) {
                 SignUpView()
             }
         }

--- a/CineHive/CineHive/Features/Auth/View/SocialLogin/KakaoLoginBtnView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SocialLogin/KakaoLoginBtnView.swift
@@ -6,11 +6,14 @@
 //
 
 import SwiftUI
+import KakaoSDKUser
 
 struct KakaoLoginBtnView: View {
+    @State private var viewModel = KaKaoLoginViewModel()
+    
     var body: some View {
         Button(action: {
-            
+            viewModel.login()
         }, label: {
             HStack {
                 Image("KakaoLogo")

--- a/CineHive/CineHive/Features/Auth/View/SocialLogin/KakaoLoginBtnView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SocialLogin/KakaoLoginBtnView.swift
@@ -12,30 +12,27 @@ struct KakaoLoginBtnView: View {
     @State private var viewModel = KaKaoLoginViewModel()
     
     var body: some View {
-        NavigationStack {
-            Button(action: {
-                viewModel.login()
-            }, label: {
-                HStack {
-                    Image("KakaoLogo")
-                        .resizable()
-                        .frame(width: 18, height: 18)
-                    Text("카카오로 계속하기")
-                        .font(.system(size: 15, weight: .bold))
-                        .foregroundStyle(.black)
-                }
-                .frame(width: 330, height: 44)
-                .background(Color("KakaoColor"))
-                .clipShape(RoundedRectangle(cornerRadius: 12))
-            })
-            
-            .fullScreenCover(isPresented: $viewModel.shouldNavigateToMain) {
-                MainTabView()
+        Button(action: {
+            viewModel.login()
+        }, label: {
+            HStack {
+                Image("KakaoLogo")
+                    .resizable()
+                    .frame(width: 18, height: 18)
+                Text("카카오로 계속하기")
+                    .font(.system(size: 15, weight: .bold))
+                    .foregroundStyle(.black)
             }
-            .fullScreenCover(isPresented: $viewModel.shouldNavigateToSignUp) {
-                SignUpView()
-            }
-        }
+            .frame(width: 330, height: 44)
+            .background(Color("KakaoColor"))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        })
         
+        .fullScreenCover(isPresented: $viewModel.shouldNavigateToMain) {
+            MainTabView()
+        }
+        .fullScreenCover(isPresented: $viewModel.shouldNavigateToSignUp) {
+            SignUpView()
+        }
     }
 }

--- a/CineHive/CineHive/Features/Auth/View/SocialLogin/KakaoLoginBtnView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SocialLogin/KakaoLoginBtnView.swift
@@ -12,20 +12,30 @@ struct KakaoLoginBtnView: View {
     @State private var viewModel = KaKaoLoginViewModel()
     
     var body: some View {
-        Button(action: {
-            viewModel.login()
-        }, label: {
-            HStack {
-                Image("KakaoLogo")
-                    .resizable()
-                    .frame(width: 18, height: 18)
-                Text("카카오로 계속하기")
-                    .font(.system(size: 15, weight: .bold))
-                    .foregroundStyle(.black)
+        NavigationStack {
+            Button(action: {
+                viewModel.login()
+            }, label: {
+                HStack {
+                    Image("KakaoLogo")
+                        .resizable()
+                        .frame(width: 18, height: 18)
+                    Text("카카오로 계속하기")
+                        .font(.system(size: 15, weight: .bold))
+                        .foregroundStyle(.black)
+                }
+                .frame(width: 330, height: 44)
+                .background(Color("KakaoColor"))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            })
+            
+            .navigationDestination(isPresented: $viewModel.shouldNavigateToMain) {
+                MainTabView()
             }
-            .frame(width: 330, height: 44)
-            .background(Color("KakaoColor"))
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-        })
+            .navigationDestination(isPresented: $viewModel.shouldNavigateToSignUp) {
+                SignUpView()
+            }
+        }
+        
     }
 }

--- a/CineHive/CineHive/Features/Auth/ViewModel/KakaoLoginViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/KakaoLoginViewModel.swift
@@ -25,55 +25,49 @@ class KaKaoLoginViewModel {
     }
     
     func login() {
-        // 카카오톡 설치 여부 확인
-        if UserApi.isKakaoTalkLoginAvailable() {
-            // 카카오톡 앱을 통한 로그인
-            UserApi.shared.loginWithKakaoTalk { (oauthToken, error) in
-                if let error = error {
-                    Logger.log(.error, category: Logger.auth, message: "카카오톡 로그인 실패: \(error.localizedDescription)")
-                } else if let token = oauthToken {
-                    Task {
-                        do {
-                            let response = try await self.userService.kakaoLogin(token: token.accessToken)
-                        } catch {
-                            print("서버 로그인 실패: \(error.localizedDescription)")
-                        }
-                    }           
-                    self.getUserInfo()
-                }
+        let loginHandler: (OAuthToken?, Error?) -> Void = { (oauthToken, error) in
+            if let error = error {
+                Logger.log(.error, category: Logger.auth, message: "카카오 로그인 실패: \(error.localizedDescription)")
+                return
             }
-        } else {
-            // 카카오 계정으로 로그인 (웹뷰 방식)
-            UserApi.shared.loginWithKakaoAccount { (oauthToken, error) in
-                if let error = error {
-                    Logger.log(.error, category: Logger.auth, message: "카카오톡 로그인 실패: \(error.localizedDescription)")
-                } else if let token = oauthToken {
-                    Task {
-                        do {
-                            let response = try await self.userService.kakaoLogin(token: token.accessToken)
-                            // 로그인 성공 후 응답 상태코드에 따라 분기
-                            switch response.statusCode {
-                            case 200:
-                                if let token = response.token {
-                                    self.shouldNavigateToMain = true
-                                } else {
-                                    print("기존 회원인데 토큰 없음")
-                                }
-                            case 201:
-                                self.shouldNavigateToSignUp = true
-                            default:
-                                print("예상치 못한 상태 코드: \(String(describing: response.statusCode))")
-                            }
-                        } catch {
-                            Logger.log(.error, category: Logger.auth, message:"서버 로그인 실패: \(error.localizedDescription)")
-                        }
+            
+            guard let token = oauthToken else {
+                Logger.log(.error, category: Logger.auth, message: "OAuth 토큰 없음")
+                return
+            }
+            
+            Task {
+                do {
+                    let response = try await self.userService.kakaoLogin(token: token.accessToken)
+                    
+                    // 토큰 저장 및 디버깅
+                    if let token = response.token {
+                        AuthManager.shared.saveToken(token)
                     }
-                    //self.getUserInfo()
+                    AuthManager.shared.debugPrintToken()
+                    
+                    // 상태 코드에 따라 화면 전환 분기
+                    switch response.statusCode {
+                    case 200:
+                        self.shouldNavigateToMain = true
+                    case 201:
+                        self.shouldNavigateToSignUp = true
+                    default:
+                        print("예상치 못한 상태 코드: \(String(describing: response.statusCode))")
+                    }
+                } catch {
+                    Logger.log(.error, category: Logger.auth, message: "서버 로그인 실패: \(error.localizedDescription)")
                 }
             }
         }
+        
+        if UserApi.isKakaoTalkLoginAvailable() {
+            UserApi.shared.loginWithKakaoTalk(completion: loginHandler)
+        } else {
+            UserApi.shared.loginWithKakaoAccount(completion: loginHandler)
+        }
     }
-  
+    
     private func getUserInfo() {
         UserApi.shared.me() { (user, error) in
             if let error = error {

--- a/CineHive/CineHive/Features/Auth/ViewModel/KakaoLoginViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/KakaoLoginViewModel.swift
@@ -16,12 +16,15 @@ import KakaoSDKUser
 class KaKaoLoginViewModel {
     
     private let userService: UserService
+    private let userState: UserState
+
     
     var shouldNavigateToMain: Bool = false
     var shouldNavigateToSignUp: Bool = false
     
-    init(userService: UserService = .shared) {
+    init(userService: UserService = .shared, userState: UserState = .shared) {
         self.userService = userService
+        self.userState = userState
     }
     
     func login() {
@@ -37,27 +40,7 @@ class KaKaoLoginViewModel {
             }
             
             Task {
-                do {
-                    let response = try await self.userService.kakaoLogin(token: token.accessToken)
-                    
-                    // 토큰 저장 및 디버깅
-                    if let token = response.token {
-                        AuthManager.shared.saveToken(token)
-                    }
-                    AuthManager.shared.debugPrintToken()
-                    
-                    // 상태 코드에 따라 화면 전환 분기
-                    switch response.statusCode {
-                    case 200:
-                        self.shouldNavigateToMain = true
-                    case 201:
-                        self.shouldNavigateToSignUp = true
-                    default:
-                        print("예상치 못한 상태 코드: \(String(describing: response.statusCode))")
-                    }
-                } catch {
-                    Logger.log(.error, category: Logger.auth, message: "서버 로그인 실패: \(error.localizedDescription)")
-                }
+                await self.userState.socialLogin(provider: .kakao, token: token.accessToken)
             }
         }
         

--- a/CineHive/CineHive/Features/Auth/ViewModel/KakaoLoginViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/KakaoLoginViewModel.swift
@@ -17,8 +17,8 @@ class KaKaoLoginViewModel {
     
     private let userService: UserService
     private let userState: UserState
-
     
+    // 네비게이션 상태
     var shouldNavigateToMain: Bool = false
     var shouldNavigateToSignUp: Bool = false
     
@@ -40,28 +40,28 @@ class KaKaoLoginViewModel {
             }
             
             Task {
-                await self.userState.socialLogin(provider: .kakao, token: token.accessToken)
+                let result = await self.userState.socialLogin(provider: .kakao, token: token.accessToken)
+                switch result {
+                case .successNavigateToMain:
+                    // MainTabView로 이동 준비
+                    print("메인으로 이동 준비 완료")
+                    self.shouldNavigateToMain = true
+                case .successNavigateToSignUp:
+                    // 회원가입 뷰로 이동 준비
+                    print("회원가입 화면 이동 준비 완료")
+                    self.shouldNavigateToSignUp = true
+                case .failure(let message):
+                    print("로그인 실패:", message)
+                }
             }
         }
         
         if UserApi.isKakaoTalkLoginAvailable() {
+            // 카카오톡 앱 로그인
             UserApi.shared.loginWithKakaoTalk(completion: loginHandler)
         } else {
+            // 카카오톡 웹 로그인
             UserApi.shared.loginWithKakaoAccount(completion: loginHandler)
-        }
-    }
-    
-    private func getUserInfo() {
-        UserApi.shared.me() { (user, error) in
-            if let error = error {
-                Logger.log(.info, category: Logger.state, message: "사용자 정보 가져오기 실패: \(error.localizedDescription)")
-            } else {
-                if let user = user {
-                    print("id: \(user.id ?? 0)")
-                    print("nickname: \(user.kakaoAccount?.profile?.nickname ?? "")")
-                    print("email: \(user.kakaoAccount?.email ?? "")")
-                }
-            }
         }
     }
 }

--- a/CineHive/CineHive/Features/Auth/ViewModel/KakaoLoginViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/KakaoLoginViewModel.swift
@@ -1,0 +1,74 @@
+//
+//  KakaoLoginViewModel.swift
+//  CineHive
+//
+//  Created by 존진 on 4/10/25.
+//
+
+import Foundation
+import UIKit
+import OSLog
+import KakaoSDKCommon
+import KakaoSDKAuth
+import KakaoSDKUser
+
+@Observable
+class KaKaoLoginViewModel {
+    
+    private let userService: UserService
+    
+    init(userService: UserService = .shared) {
+        self.userService = userService
+    }
+    
+    func login() {
+        // 카카오톡 설치 여부 확인
+        if UserApi.isKakaoTalkLoginAvailable() {
+            // 카카오톡 앱을 통한 로그인
+            UserApi.shared.loginWithKakaoTalk { (oauthToken, error) in
+                if let error = error {
+                    Logger.log(.error, category: Logger.auth, message: "카카오톡 로그인 실패: \(error.localizedDescription)")
+                } else if let token = oauthToken {
+                    Task {
+                        do {
+                            let response = try await self.userService.kakaoLogin(token: token.accessToken)
+                        } catch {
+                            print("서버 로그인 실패: \(error.localizedDescription)")
+                        }
+                    }           
+                    self.getUserInfo()
+                }
+            }
+        } else {
+            // 카카오 계정으로 로그인 (웹뷰 방식)
+            UserApi.shared.loginWithKakaoAccount { (oauthToken, error) in
+                if let error = error {
+                    Logger.log(.error, category: Logger.auth, message: "카카오톡 로그인 실패: \(error.localizedDescription)")
+                } else if let token = oauthToken {
+                    Task {
+                        do {
+                            let response = try await self.userService.kakaoLogin(token: token.accessToken)
+                        } catch {
+                            Logger.log(.error, category: Logger.auth, message:"서버 로그인 실패: \(error.localizedDescription)")
+                        }
+                    }
+                    self.getUserInfo()
+                }
+            }
+        }
+    }
+  
+    private func getUserInfo() {
+        UserApi.shared.me() { (user, error) in
+            if let error = error {
+                Logger.log(.info, category: Logger.state, message: "사용자 정보 가져오기 실패: \(error.localizedDescription)")
+            } else {
+                if let user = user {
+                    print("id: \(user.id ?? 0)")
+                    print("nickname: \(user.kakaoAccount?.profile?.nickname ?? "")")
+                    print("email: \(user.kakaoAccount?.email ?? "")")
+                }
+            }
+        }
+    }
+}

--- a/CineHive/CineHive/Features/Auth/ViewModel/KakaoLoginViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/KakaoLoginViewModel.swift
@@ -17,6 +17,9 @@ class KaKaoLoginViewModel {
     
     private let userService: UserService
     
+    var shouldNavigateToMain: Bool = false
+    var shouldNavigateToSignUp: Bool = false
+    
     init(userService: UserService = .shared) {
         self.userService = userService
     }
@@ -48,11 +51,24 @@ class KaKaoLoginViewModel {
                     Task {
                         do {
                             let response = try await self.userService.kakaoLogin(token: token.accessToken)
+                            // 로그인 성공 후 응답 상태코드에 따라 분기
+                            switch response.statusCode {
+                            case 200:
+                                if let token = response.token {
+                                    self.shouldNavigateToMain = true
+                                } else {
+                                    print("기존 회원인데 토큰 없음")
+                                }
+                            case 201:
+                                self.shouldNavigateToSignUp = true
+                            default:
+                                print("예상치 못한 상태 코드: \(String(describing: response.statusCode))")
+                            }
                         } catch {
                             Logger.log(.error, category: Logger.auth, message:"서버 로그인 실패: \(error.localizedDescription)")
                         }
                     }
-                    self.getUserInfo()
+                    //self.getUserInfo()
                 }
             }
         }

--- a/CineHive/CineHive/Features/Auth/ViewModel/KakaoLoginViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/KakaoLoginViewModel.swift
@@ -21,6 +21,7 @@ class KaKaoLoginViewModel {
     // 네비게이션 상태
     var shouldNavigateToMain: Bool = false
     var shouldNavigateToSignUp: Bool = false
+    var toast: ToastState = ToastState()
     
     init(userService: UserService = .shared, userState: UserState = .shared) {
         self.userService = userService
@@ -44,14 +45,12 @@ class KaKaoLoginViewModel {
                 switch result {
                 case .successNavigateToMain:
                     // MainTabView로 이동 준비
-                    print("메인으로 이동 준비 완료")
                     self.shouldNavigateToMain = true
                 case .successNavigateToSignUp:
                     // 회원가입 뷰로 이동 준비
-                    print("회원가입 화면 이동 준비 완료")
                     self.shouldNavigateToSignUp = true
                 case .failure(let message):
-                    print("로그인 실패:", message)
+                    self.toast = ToastState(isShowing: true, message: message.message, type: .error)
                 }
             }
         }

--- a/CineHive/CineHive/Services/UserService.swift
+++ b/CineHive/CineHive/Services/UserService.swift
@@ -54,7 +54,7 @@ final class UserService {
     // MARK: - 소셜 로그인 관련
     
     /// 구글 로그인
-    func googleLogin(token: String) async throws -> LoginResponse {
+    func googleLogin(token: String) async throws -> SocialLoginResponse {
         let endpoint = EndPoint.GoogleAuth.appLogin
         
         struct SocialLoginRequest: Codable {
@@ -66,7 +66,7 @@ final class UserService {
     }
     
     /// 네이버 로그인
-    func naverLogin(token: String) async throws -> LoginResponse {
+    func naverLogin(token: String) async throws -> SocialLoginResponse {
         let endpoint = EndPoint.NaverAuth.appLogin
         
         struct SocialLoginRequest: Codable {
@@ -78,7 +78,7 @@ final class UserService {
     }
     
     /// 카카오 로그인
-    func kakaoLogin(token: String) async throws -> LoginResponse {
+    func kakaoLogin(token: String) async throws -> SocialLoginResponse {
         let endpoint = EndPoint.KakaoAuth.appLogin
         
         struct SocialLoginRequest: Codable {


### PR DESCRIPTION
## 작업한 내용
- Kakao SDK 초기화 코드 작성
- KakaoLoginViewModel 구현
- 카카오톡 앱/웹 로그인 처리
- 로그인 성공 시 토큰 저장 및 사용자 정보 처리
- 로그인 상태에 따라 메인 or 회원가입 화면 이동
- UserState에 소셜 로그인 응답 처리 로직 추가
- SocialLoginError enum 도입 및 상세 오류 케이스 분류
- ToastState를 활용한 오류 메시지 처리

## PR Point
- 앱 설치 여부에 따라 카카오톡 앱 로그인 / 웹 로그인 분기 처리
- JWT 토큰 키체인 저장 및 디버깅용 로그 출력 추가
    - AuthManager에 saveToken, debugPrintToken 메소드 작성 
- 강제 타입 캐스팅(as! T) 제거 및 제네릭 + 프로토콜을 활용한 안전한 타입 처리
- 소셜 로그인 실패 시 ToastState를 활용한 오류 메시지 처리

### 추후 작업할 내용 (미완성 부분)
<!-- 이슈 번호와 함께 향후 작업 예정인 내용을 작성해주세요 -->
<!-- 연결된 이슈가 있다면 작성해주세요 (예: #123) -->
<!-- 체크리스트 작성 (예: - [ ]) -->
- 서버 URL 설정 분리 및 환경에 따른 처리
    - 현재 'localhost'로 설정되어 있어 실제 기기에서 연결이 불가능

## 실행 영상
<!-- UI 변경이 있는 경우 변경 전/후 스크린샷을 첨부해주세요 -->
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/3fc52e2c-7936-49ce-8dcd-c975daef486d" width="200"><br>
      <p>카카오 앱 연결 로그인</p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/b5c71611-c5b4-4515-8e96-c89110b6ee1f" width="200"><br>
      <p>카카오 웹 연결 로그인</p>
    </td>
  </tr>
</table> 
