### PR TITLE
[Feature/social-google]: 구글 소셜 로그인 기능 구현

### DIFF
--- a/CineHive/CineHive.xcodeproj/project.pbxproj
+++ b/CineHive/CineHive.xcodeproj/project.pbxproj
@@ -185,13 +185,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-CineHive/Pods-CineHive-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-CineHive/Pods-CineHive-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/CineHive/CineHive.xcodeproj/project.pbxproj
+++ b/CineHive/CineHive.xcodeproj/project.pbxproj
@@ -185,9 +185,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-CineHive/Pods-CineHive-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-CineHive/Pods-CineHive-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/CineHive/CineHive/App/CineHiveApp.swift
+++ b/CineHive/CineHive/App/CineHiveApp.swift
@@ -10,6 +10,7 @@ import KakaoSDKCommon
 import KakaoSDKAuth
 import NaverThirdPartyLogin
 import GoogleSignIn
+import OSLog
 
 @main
 struct CineHiveApp: App {
@@ -42,11 +43,19 @@ struct CineHiveApp: App {
         WindowGroup {
             // onOpenURL()을 사용해 커스텀 URL 스킴 처리
             ContentView().onOpenURL(perform: { url in
-                if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                if AuthApi.isKakaoTalkLoginUrl(url) {
+                    // Kakao 로그인 URL
                     AuthController.handleOpenUrl(url: url)
+                } else if url.scheme == Bundle.main.object(forInfoDictionaryKey: "NAVER_URL_SCHEME") as? String,
+                          url.host == "oauth" {
+                    // Naver 로그인 URL
+                    NaverThirdPartyLoginConnection.getSharedInstance()?.receiveAccessToken(url)
+                } else if url.scheme?.hasPrefix("com.googleusercontent.apps") == true {
+                    // Google 로그인 URL
+                    _ = GIDSignIn.sharedInstance.handle(url)
+                } else {
+                    Logger.log(.info, category: Logger.auth, message: "처리되지 않은 URL: \(url)")
                 }
-                NaverThirdPartyLoginConnection.getSharedInstance()?.receiveAccessToken(url)
-                GIDSignIn.sharedInstance.handle(url)
             })
             .environment(userState)
         }

--- a/CineHive/CineHive/App/CineHiveApp.swift
+++ b/CineHive/CineHive/App/CineHiveApp.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import KakaoSDKCommon
 import KakaoSDKAuth
 import NaverThirdPartyLogin
+import GoogleSignIn
 
 @main
 struct CineHiveApp: App {
@@ -45,6 +46,7 @@ struct CineHiveApp: App {
                     AuthController.handleOpenUrl(url: url)
                 }
                 NaverThirdPartyLoginConnection.getSharedInstance()?.receiveAccessToken(url)
+                GIDSignIn.sharedInstance.handle(url)
             })
             .environment(userState)
         }

--- a/CineHive/CineHive/Core/Utils/UIApplication+Extension.swift
+++ b/CineHive/CineHive/Core/Utils/UIApplication+Extension.swift
@@ -1,0 +1,19 @@
+//
+//  UIApplication+Extension.swift
+//  CineHive
+//
+//  Created by 존진 on 5/22/25.
+//
+
+import Foundation
+import UIKit
+
+extension UIApplication {
+    // 현재 앱의 최상위 루트 뷰 컨트롤러를 반환
+    func rootViewController() -> UIViewController? {
+        connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first?.windows
+            .first?.rootViewController
+    }
+}

--- a/CineHive/CineHive/Features/Auth/View/SocialLogin/GoogleLoginBtnView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SocialLogin/GoogleLoginBtnView.swift
@@ -8,9 +8,16 @@
 import SwiftUI
 
 struct GoogleLoginBtnView: View {
+    @State private var viewModel = GoogleLoginViewModel()
+    
     var body: some View {
         Button(action: {
-            
+            if let rootVC = UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene })
+                .first?.windows
+                .first?.rootViewController {
+                viewModel.login(presentingViewController: rootVC)
+            }
         }, label: {
             HStack {
                 Image("GoogleLogo")
@@ -25,5 +32,11 @@ struct GoogleLoginBtnView: View {
             .background(Color("GoogleColor"))
             .clipShape(RoundedRectangle(cornerRadius: 12))
         })
+        .fullScreenCover(isPresented: $viewModel.shouldNavigateToMain) {
+            MainTabView()
+        }
+        .fullScreenCover(isPresented: $viewModel.shouldNavigateToSignUp) {
+            SignUpView()
+        }
     }
 }

--- a/CineHive/CineHive/Features/Auth/View/SocialLogin/GoogleLoginBtnView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SocialLogin/GoogleLoginBtnView.swift
@@ -12,10 +12,7 @@ struct GoogleLoginBtnView: View {
     
     var body: some View {
         Button(action: {
-            if let rootVC = UIApplication.shared.connectedScenes
-                .compactMap({ $0 as? UIWindowScene })
-                .first?.windows
-                .first?.rootViewController {
+            if let rootVC = UIApplication.shared.rootViewController() {
                 viewModel.login(presentingViewController: rootVC)
             }
         }, label: {

--- a/CineHive/CineHive/Features/Auth/ViewModel/GoogleLoginViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/GoogleLoginViewModel.swift
@@ -1,0 +1,59 @@
+//
+//  GoogleLoginViewModel.swift
+//  CineHive
+//
+//  Created by 존진 on 5/20/25.
+//
+
+import Foundation
+import GoogleSignIn
+import SwiftUI
+
+@Observable
+class GoogleLoginViewModel {
+    
+    private let userService: UserService
+    private let userState: UserState
+    
+    // 네비게이션 상태
+    var shouldNavigateToMain: Bool = false
+    var shouldNavigateToSignUp: Bool = false
+    var toast: ToastState = ToastState()
+    
+    init(userService: UserService = .shared, userState: UserState = .shared) {
+        self.userService = userService
+        self.userState = userState
+    }
+    
+    func login(presentingViewController: UIViewController) {
+        GIDSignIn.sharedInstance.signIn(withPresenting: presentingViewController) { signInResult, error in
+            guard error == nil else { return }
+            guard let signInResult = signInResult else { return }
+
+            signInResult.user.refreshTokensIfNeeded { user, error in
+                guard error == nil else { return }
+                guard let user = user else { return }
+
+                guard let idToken = user.idToken?.tokenString else {
+                    // 토큰이 없으면 로그인 실패 처리
+                    self.toast = ToastState(isShowing: true, message: "Google 로그인 토큰이 유효하지 않습니다.", type: .error)
+                    return
+                }
+                
+                Task {
+                    let result = await self.userState.socialLogin(provider: .google, token: idToken)
+                    switch result {
+                    case .successNavigateToMain:
+                        // MainTabView로 이동 준비
+                        self.shouldNavigateToMain = true
+                    case .successNavigateToSignUp:
+                        // 회원가입 뷰로 이동 준비
+                        self.shouldNavigateToSignUp = true
+                    case .failure(let message):
+                        self.toast = ToastState(isShowing: true, message: message.message, type: .error)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/CineHive/CineHive/Features/Auth/ViewModel/GoogleLoginViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/GoogleLoginViewModel.swift
@@ -42,12 +42,14 @@ class GoogleLoginViewModel {
 
     // 사용자 토큰 새로고침하고 로그인 처리
     private func refreshGoogleTokenAndLogin(signInResult: GIDSignInResult) {
-        Task {
+        Task { [weak self] in
+            guard let self else { return }
+            
             var retryCount = 0
             let maxRetries = 3
 
             while retryCount < maxRetries {
-                let (fetchedUser, fetchError) = await refreshGoogleUser(signInResult.user)
+                let (fetchedUser, fetchError) = await self.refreshGoogleUser(signInResult.user)
 
                 if let error = fetchError {
                     retryCount += 1

--- a/CineHive/CineHive/Features/Auth/ViewModel/GoogleLoginViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/GoogleLoginViewModel.swift
@@ -27,15 +27,36 @@ class GoogleLoginViewModel {
     
     // Google 로그인 플로우를 시작하고 로그인 처리
     func login(presentingViewController: UIViewController) {
-        GIDSignIn.sharedInstance.signIn(withPresenting: presentingViewController) { signInResult, error in
+        guard let clientID = Bundle.main.object(forInfoDictionaryKey: "GIDClientID") as? String else {
+            self.toast = ToastState(isShowing: true, message: "Google Client ID를 불러올 수 없습니다.", type: .error)
+            return
+        }
+
+        let scopes = [
+            "https://www.googleapis.com/auth/userinfo.profile",
+            "https://www.googleapis.com/auth/userinfo.email"
+        ]
+
+        let config = GIDConfiguration(clientID: clientID)
+        GIDSignIn.sharedInstance.configuration = config
+
+        GIDSignIn.sharedInstance.signIn(
+            withPresenting: presentingViewController,
+            hint: nil,
+            additionalScopes: scopes
+        ) { [weak self] result, error in
+            guard let self else { return }
+
             if let error = error {
                 self.toast = ToastState(isShowing: true, message: "Google 로그인 중 오류 발생: \(error.localizedDescription)", type: .error)
                 return
             }
-            guard let signInResult = signInResult else {
+
+            guard let signInResult = result else {
                 self.toast = ToastState(isShowing: true, message: "Google 로그인 결과가 없습니다.", type: .error)
                 return
             }
+
             self.refreshGoogleTokenAndLogin(signInResult: signInResult)
         }
     }

--- a/CineHive/CineHive/Features/Auth/ViewModel/GoogleLoginViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/GoogleLoginViewModel.swift
@@ -27,12 +27,24 @@ class GoogleLoginViewModel {
     
     func login(presentingViewController: UIViewController) {
         GIDSignIn.sharedInstance.signIn(withPresenting: presentingViewController) { signInResult, error in
-            guard error == nil else { return }
-            guard let signInResult = signInResult else { return }
+            if let error = error {
+                self.toast = ToastState(isShowing: true, message: "Google 로그인 중 오류 발생: \(error.localizedDescription)", type: .error)
+                return
+            }
+            guard let signInResult = signInResult else {
+                self.toast = ToastState(isShowing: true, message: "Google 로그인 결과가 없습니다.", type: .error)
+                return
+            }
 
             signInResult.user.refreshTokensIfNeeded { user, error in
-                guard error == nil else { return }
-                guard let user = user else { return }
+                if let error = error {
+                    self.toast = ToastState(isShowing: true, message: "Google 토큰 갱신 실패: \(error.localizedDescription)", type: .error)
+                    return
+                }
+                guard let user = user else {
+                    self.toast = ToastState(isShowing: true, message: "Google 사용자 정보를 가져올 수 없습니다.", type: .error)
+                    return
+                }
 
                 guard let idToken = user.idToken?.tokenString else {
                     // 토큰이 없으면 로그인 실패 처리

--- a/CineHive/CineHive/Features/Auth/ViewModel/GoogleLoginViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/GoogleLoginViewModel.swift
@@ -25,6 +25,7 @@ class GoogleLoginViewModel {
         self.userState = userState
     }
     
+    // Google 로그인 플로우를 시작하고 로그인 처리
     func login(presentingViewController: UIViewController) {
         GIDSignIn.sharedInstance.signIn(withPresenting: presentingViewController) { signInResult, error in
             if let error = error {
@@ -35,36 +36,62 @@ class GoogleLoginViewModel {
                 self.toast = ToastState(isShowing: true, message: "Google 로그인 결과가 없습니다.", type: .error)
                 return
             }
+            self.refreshGoogleTokenAndLogin(signInResult: signInResult)
+        }
+    }
 
-            signInResult.user.refreshTokensIfNeeded { user, error in
-                if let error = error {
-                    self.toast = ToastState(isShowing: true, message: "Google 토큰 갱신 실패: \(error.localizedDescription)", type: .error)
-                    return
+    // 사용자 토큰 새로고침하고 로그인 처리
+    private func refreshGoogleTokenAndLogin(signInResult: GIDSignInResult) {
+        Task {
+            var retryCount = 0
+            let maxRetries = 3
+
+            while retryCount < maxRetries {
+                let (fetchedUser, fetchError) = await refreshGoogleUser(signInResult.user)
+
+                if let error = fetchError {
+                    retryCount += 1
+                    if retryCount >= maxRetries {
+                        self.toast = ToastState(isShowing: true, message: "Google 토큰 갱신 실패: \(error.localizedDescription)", type: .error)
+                        return
+                    }
+                    continue
                 }
-                guard let user = user else {
-                    self.toast = ToastState(isShowing: true, message: "Google 사용자 정보를 가져올 수 없습니다.", type: .error)
-                    return
+
+                guard let user = fetchedUser else {
+                    retryCount += 1
+                    if retryCount >= maxRetries {
+                        self.toast = ToastState(isShowing: true, message: "Google 사용자 정보를 가져올 수 없습니다.", type: .error)
+                        return
+                    }
+                    continue
                 }
 
                 guard let idToken = user.idToken?.tokenString else {
-                    // 토큰이 없으면 로그인 실패 처리
                     self.toast = ToastState(isShowing: true, message: "Google 로그인 토큰이 유효하지 않습니다.", type: .error)
                     return
                 }
-                
-                Task {
-                    let result = await self.userState.socialLogin(provider: .google, token: idToken)
-                    switch result {
-                    case .successNavigateToMain:
-                        // MainTabView로 이동 준비
-                        self.shouldNavigateToMain = true
-                    case .successNavigateToSignUp:
-                        // 회원가입 뷰로 이동 준비
-                        self.shouldNavigateToSignUp = true
-                    case .failure(let message):
-                        self.toast = ToastState(isShowing: true, message: message.message, type: .error)
-                    }
+
+                let result = await self.userState.socialLogin(provider: .google, token: idToken)
+                switch result {
+                case .successNavigateToMain:
+                    self.shouldNavigateToMain = true
+                case .successNavigateToSignUp:
+                    self.shouldNavigateToSignUp = true
+                case .failure(let message):
+                    self.toast = ToastState(isShowing: true, message: message.message, type: .error)
                 }
+                return
+            }
+
+            self.toast = ToastState(isShowing: true, message: "Google 토큰 갱신이 반복 실패했습니다.", type: .error)
+        }
+    }
+    
+    private func refreshGoogleUser(_ user: GIDGoogleUser) async -> (GIDGoogleUser?, Error?) {
+        await withCheckedContinuation { continuation in
+            user.refreshTokensIfNeeded { refreshedUser, error in
+                continuation.resume(returning: (refreshedUser, error))
             }
         }
     }

--- a/CineHive/Podfile
+++ b/CineHive/Podfile
@@ -15,5 +15,6 @@ target 'CineHive' do
   pod 'KakaoSDKAuth'
   pod 'KakaoSDKUser'
   pod 'KakaoSDKShare'
+  pod 'GoogleSignInSwiftSupport'
 
 end

--- a/CineHive/Podfile.lock
+++ b/CineHive/Podfile.lock
@@ -1,5 +1,35 @@
 PODS:
   - Alamofire (5.9.1)
+  - AppAuth (1.7.6):
+    - AppAuth/Core (= 1.7.6)
+    - AppAuth/ExternalUserAgent (= 1.7.6)
+  - AppAuth/Core (1.7.6)
+  - AppAuth/ExternalUserAgent (1.7.6):
+    - AppAuth/Core
+  - AppCheckCore (11.2.0):
+    - GoogleUtilities/Environment (~> 8.0)
+    - GoogleUtilities/UserDefaults (~> 8.0)
+    - PromisesObjC (~> 2.4)
+  - GoogleSignIn (8.0.0):
+    - AppAuth (< 2.0, >= 1.7.3)
+    - AppCheckCore (~> 11.0)
+    - GTMAppAuth (< 5.0, >= 4.1.1)
+    - GTMSessionFetcher/Core (~> 3.3)
+  - GoogleSignInSwiftSupport (8.0.0):
+    - GoogleSignIn (~> 8.0)
+  - GoogleUtilities/Environment (8.0.2):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Logger (8.0.2):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Privacy (8.0.2)
+  - GoogleUtilities/UserDefaults (8.0.2):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
+  - GTMAppAuth (4.1.1):
+    - AppAuth/Core (~> 1.7)
+    - GTMSessionFetcher/Core (< 4.0, >= 3.3)
+  - GTMSessionFetcher/Core (3.5.0)
   - KakaoSDKAuth (2.22.7):
     - KakaoSDKCommon (= 2.22.7)
   - KakaoSDKCommon (2.22.7):
@@ -17,9 +47,11 @@ PODS:
   - KakaoSDKUser (2.22.7):
     - KakaoSDKAuth (= 2.22.7)
   - naveridlogin-sdk-ios (4.2.3)
+  - PromisesObjC (2.4.0)
   - youtube-ios-player-helper (1.0.4)
 
 DEPENDENCIES:
+  - GoogleSignInSwiftSupport
   - KakaoSDKAuth
   - KakaoSDKCommon
   - KakaoSDKShare
@@ -30,24 +62,40 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - Alamofire
+    - AppAuth
+    - AppCheckCore
+    - GoogleSignIn
+    - GoogleSignInSwiftSupport
+    - GoogleUtilities
+    - GTMAppAuth
+    - GTMSessionFetcher
     - KakaoSDKAuth
     - KakaoSDKCommon
     - KakaoSDKShare
     - KakaoSDKTemplate
     - KakaoSDKUser
     - naveridlogin-sdk-ios
+    - PromisesObjC
     - youtube-ios-player-helper
 
 SPEC CHECKSUMS:
   Alamofire: f36a35757af4587d8e4f4bfa223ad10be2422b8c
+  AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
+  AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
+  GoogleSignIn: ce8c89bb9b37fb624b92e7514cc67335d1e277e4
+  GoogleSignInSwiftSupport: de6a0f0c2f0f7420d77a58275fbef7c7f4fcf3c2
+  GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
+  GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
+  GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   KakaoSDKAuth: 45204252ff7c379c0f86c5573f97ec36885afca0
   KakaoSDKCommon: 132164a6bac8bcd3a4346d3bf777f34f8f39fdca
   KakaoSDKShare: 01c60c3d5394479429a51ef14ea78d3e72f48af0
   KakaoSDKTemplate: b11ecf08777198ffafd184201baf93de476ddb84
   KakaoSDKUser: 4c9cf1da78710d19d0b2c2dd32d1a44c544cdfa4
   naveridlogin-sdk-ios: d9d46d02119d303023d7000cd5963864d5bb89e5
+  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   youtube-ios-player-helper: e9b97535e816db3152179d84d999bc1807ecd689
 
-PODFILE CHECKSUM: fe14a63ab54bfa5133be1b969275da52a0a7f90a
+PODFILE CHECKSUM: 8fd120f9a8c3f30696408469410c7a0ada673fde
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
## 작업한 내용
- 버튼 클릭 시 UIApplication을 통해 rootViewController를 추출하여 ViewModel에 전달
- GIDSignIn.sharedInstance.signIn을 활용한 로그인 처리 로직 구현
- 로그인 성공 시 IDToken을 추출하여 서버에 전달
- 서버 응답 상태에 따라 MainTabView 또는 SignUpView로 이동 처리
- 로그인 시 발생할 수 있는 오류에 대해 상세한 메시지를 표시하도록 수정
    - 각 케이스에 대해 각 Toast 메시지 추가
- 토큰 갱신 실패 시 최대 3회 재시도 로직 구현
    - 에러 발생 및 사용자 정보 미존재 시 Toast 메시지 표시
- 카카오, 네이버, 구글 로그인 URL을 각각 구분해 처리하도록 onOpenURL 분기 구조 수정
- rootViewController() 메소드를 통해 루트 뷰 컨트롤러 접근 로직을 재사용 가능하게 분리
- 메모리 누수 방지를 위해 weak self 적용
    - self로 인한 순환참조 예방
- 로그인 요청 시 사용자 이메일, 프로필 정보를 가져오기 위한 스코프 명시

## PR Point
- SwiftUI는 UIKit 기반의 UIViewController 구조와 분리되어 있기 때문에 구글 로그인과 같이 UIViewController를 요구하는 API(GIDSignIn.signIn 등)를 직접 사용할 수 없음
    - 해결하기 위해 UIApplication.shared.connectedScenes를 통해 현재 활성화된 UIWindowScene을 찾고 그 안의 rootViewController를 추출하여 Google 로그인 메서드의 presentingViewController로 전달
- 코드 흐름을 명확히 하고, 재사용 가능한 구조로 개선
- ViewModel의 메모리 해제를 보장하기 위한 weak self 적용

### 추후 작업할 내용 (미완성 부분)
<!-- 이슈 번호와 함께 향후 작업 예정인 내용을 작성해주세요 -->
<!-- 연결된 이슈가 있다면 작성해주세요 (예: #123) -->
<!-- 체크리스트 작성 (예: - [ ]) -->
- 서버 URL 설정 분리 및 환경에 따른 처리
    - 현재 'localhost'로 설정되어 있어 실제 기기에서 연결이 불가능

## 스크린샷
<!-- UI 변경이 있는 경우 변경 전/후 스크린샷을 첨부해주세요 -->
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/f0683a89-034b-437b-9327-d38053368e3d" width="200"><br>
      <p>신규 회원</p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/0b6554af-ca6f-428f-80b1-dc364f84601d" width="200"><br>
      <p>기존 회원</p>
    </td>
  </tr>
</table> 
