### PR TITLE
[Feature/refactor-auth-google]: 구글 소셜 로그인 리팩토링

### DIFF
--- a/CineHive/CineHive/Core/Network/EndPoint.swift
+++ b/CineHive/CineHive/Core/Network/EndPoint.swift
@@ -152,7 +152,7 @@ enum EndPoint {
         static let loginSuccess = "/api/auth/google/login/success"
         static let callback = "/api/auth/google/callback"
         static let register = "/api/auth/google/register"
-        static let appLogin = "/api/auth/google/app-login"
+        static let appLogin = "/api/v1/oauth2/app/login/google"
     }
 
     enum NaverAuth {

--- a/CineHive/CineHive/Features/Auth/ViewModel/GoogleLoginViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/GoogleLoginViewModel.swift
@@ -89,12 +89,9 @@ class GoogleLoginViewModel {
                     continue
                 }
 
-                guard let idToken = user.idToken?.tokenString else {
-                    self.toast = ToastState(isShowing: true, message: "Google 로그인 토큰이 유효하지 않습니다.", type: .error)
-                    return
-                }
-
-                let result = await self.userState.socialLogin(provider: .google, token: idToken)
+                let accessToken = user.accessToken.tokenString
+                
+                let result = await self.userState.socialLogin(provider: .google, token: accessToken)
                 switch result {
                 case .successNavigateToMain:
                     self.shouldNavigateToMain = true

--- a/CineHive/CineHive/Services/UserService.swift
+++ b/CineHive/CineHive/Services/UserService.swift
@@ -58,10 +58,10 @@ final class UserService {
         let endpoint = EndPoint.GoogleAuth.appLogin
         
         struct SocialLoginRequest: Codable {
-            let token: String
+            let accessToken: String
         }
         
-        let request = SocialLoginRequest(token: token)
+        let request = SocialLoginRequest(accessToken: token)
         return try await NetworkManager.shared.post(endpoint: endpoint, body: request)
     }
     


### PR DESCRIPTION
## 작업한 내용
- 클라이언트에서 기존에 idToken을 전달하던 로직을 accessToken 전달로 변경
- 서버 요청 바디에서 기대하는 필드명(accessToken)에 따라 SocialLoginRequest 구조체 필드명 token -> accessToken 으로 변경
- 서버 요청 엔트포인트 변경

## PR Point
- 서버 요청 형식에 맞춰 구조 반영

### 추후 작업할 내용 (미완성 부분)
<!-- 이슈 번호와 함께 향후 작업 예정인 내용을 작성해주세요 -->
<!-- 연결된 이슈가 있다면 작성해주세요 (예: #123) -->
<!-- 체크리스트 작성 (예: - [ ]) -->
X

## 스크린샷
<!-- UI 변경이 있는 경우 변경 전/후 스크린샷을 첨부해주세요 -->
X
