### PR TITLE
[Feature/refactor-signup]: 회원가입 화면 로직 및 UI 개선

### DIFF
--- a/CineHive/CineHive.xcodeproj/project.pbxproj
+++ b/CineHive/CineHive.xcodeproj/project.pbxproj
@@ -339,6 +339,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"CineHive/Resources/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = CineHive/Info.plist;
@@ -370,6 +371,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"CineHive/Resources/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = CineHive/Info.plist;

--- a/CineHive/CineHive/Core/Models/Board.swift
+++ b/CineHive/CineHive/Core/Models/Board.swift
@@ -55,13 +55,12 @@ struct Board: Identifiable, Codable {
         } else {
             let nickname = try container.decodeIfPresent(String.self, forKey: .nickname) ?? "알 수 없음"
             self.user = User(
-                id: nil,
                 email: "unknown@email.com",
                 password: "",
-                nickname: nickname,
                 name: nil,
+                nickname: nickname,
                 gender: nil,
-                type: "일반"
+                genres: nil
             )
         }
     }

--- a/CineHive/CineHive/Core/Models/User.swift
+++ b/CineHive/CineHive/Core/Models/User.swift
@@ -7,34 +7,31 @@
 
 import Foundation
 
-struct User: Codable, Identifiable {
-    let id: Int?
+struct User: Codable {
     let email: String
     let password: String
-    let nickname: String
     let name: String?
+    let nickname: String
     let gender: String?
-    let type: String
+    let genres: [String]?
     
     enum CodingKeys: String, CodingKey {
-        case id = "mem_id"
-        case email = "memEmail"
-        case password = "memPassword"
-        case nickname = "memNickname"
-        case name = "memName"
-        case gender = "memSex"
-        case type = "memType"
+        case email
+        case password
+        case name
+        case nickname
+        case gender
+        case genres
     }
     
     // 기본 생성자
-    init(id: Int? = nil, email: String, password: String, nickname: String, name: String?, gender: String?, type: String) {
-        self.id = id
+    init(email: String, password: String, name: String?, nickname: String, gender: String?, genres: [String]?) {
         self.email = email
         self.password = password
-        self.nickname = nickname
         self.name = name
+        self.nickname = nickname
         self.gender = gender
-        self.type = type
+        self.genres = genres
     }
 }
 
@@ -48,8 +45,8 @@ struct LoginUser: Codable {
     }
     
     enum CodingKeys: String, CodingKey {
-        case email = "memEmail"
-        case password = "memPassword"
+        case email
+        case password
     }
 }
 

--- a/CineHive/CineHive/Core/Models/User.swift
+++ b/CineHive/CineHive/Core/Models/User.swift
@@ -93,9 +93,39 @@ struct UserData: Codable {
     }
 }
 
+struct SignUpRequest: Codable {
+    let email: String
+    let password: String
+    let name: String?
+    let nickname: String
+    let gender: String?
+    let genres: [String]
+}
+
 struct SignUpResponse: Codable {
+    let success: Bool
+    let data: SignUpResponseData
+    let error: ErrorResponse?
+}
+
+struct SignUpResponseData: Codable {
     let message: String
-    let status: String
+}
+
+struct ErrorResponse: Codable {
+    let timestamp: String
+    let status: Int
+    let code: String
+    let error: String
+    let message: String
+    let path: String
+    let details: [ErrorDetail]?
+}
+
+struct ErrorDetail: Codable {
+    let field: String
+    let rejectedValue: String
+    let reason: String
 }
 
 struct AvailabilityResponse: Decodable {

--- a/CineHive/CineHive/Core/Models/User.swift
+++ b/CineHive/CineHive/Core/Models/User.swift
@@ -97,3 +97,12 @@ struct SignUpResponse: Codable {
     let message: String
     let status: String
 }
+
+struct AvailabilityResponse: Decodable {
+    let success: Bool
+    let data: AvailabilityData
+}
+
+struct AvailabilityData: Decodable {
+    let isAvailable: Bool
+}

--- a/CineHive/CineHive/Core/Models/User.swift
+++ b/CineHive/CineHive/Core/Models/User.swift
@@ -93,6 +93,7 @@ struct UserData: Codable {
 struct SignUpRequest: Codable {
     let email: String
     let password: String
+    let confirmPassword: String
     let name: String?
     let nickname: String
     let gender: String?

--- a/CineHive/CineHive/Core/Network/EndPoint.swift
+++ b/CineHive/CineHive/Core/Network/EndPoint.swift
@@ -142,8 +142,8 @@ enum EndPoint {
     enum Auth {
         static let register = "/register"
         static let login = "/login"
-        static func checkNickname(_ nickname: String) -> String { "/checknickname/\(nickname)" }
-        static func checkEmail(_ email: String) -> String { "/checkemail/\(email)" }
+        static func checkNickname(_ nickname: String) -> String { "/api/v1/auth/check-nickname?nickname=\(nickname)" }
+        static func checkEmail(_ email: String) -> String { "/api/v1/auth/check-email?email=\(email)" }
     }
 
     enum GoogleAuth {

--- a/CineHive/CineHive/Core/State/UserState.swift
+++ b/CineHive/CineHive/Core/State/UserState.swift
@@ -186,7 +186,7 @@ final class UserState {
     
     /// 회원가입 처리
     @MainActor
-    func signUp(user: User) async -> Bool {
+    func signUp(user: SignUpRequest) async -> Bool {
         isLoading = true
         errorMessage = nil
         
@@ -194,12 +194,12 @@ final class UserState {
             let response = try await UserService.shared.registerUser(user: user)
             isLoading = false
             
-            if response.status == "success" {
-                Logger.log(.info, category: Logger.auth, message: "회원가입 성공: \(user.email)")
+            if response.success == true {
+                Logger.log(.info, category: Logger.auth, message: "회원가입 성공: \(response.data.message)")
                 return true
             } else {
-                self.errorMessage = response.message
-                Logger.log(.error, category: Logger.auth, message: "회원가입 실패: \(response.message)")
+                self.errorMessage = response.error?.message
+                Logger.log(.error, category: Logger.auth, message: "회원가입 실패: \(String(describing: errorMessage))")
                 return false
             }
         } catch let error as NetworkError {

--- a/CineHive/CineHive/Core/State/UserState.swift
+++ b/CineHive/CineHive/Core/State/UserState.swift
@@ -217,25 +217,25 @@ final class UserState {
     
     /// 닉네임 중복 확인
     @MainActor
-    func checkNickname(_ nickname: String) async -> (isAvailable: Bool, errorMessage: String?) {
+    func checkNickname(_ nickname: String) async -> (success: Bool, data: Bool) {
         do {
-            let isAvailable = try await UserService.shared.fetchUserNickname(nickname: nickname)
-            return (isAvailable, nil)
+            let response = try await UserService.shared.fetchUserNickname(nickname: nickname)
+            return (response.success, response.data.isAvailable)
         } catch {
             Logger.log(.error, category: Logger.auth, message: "닉네임 중복 검사 실패: \(error.localizedDescription)")
-            return (false, "닉네임 중복 검사 실패: \(error.localizedDescription)")
+            return (false, false)
         }
     }
     
     /// 이메일 중복 확인
     @MainActor
-    func checkEmail(_ email: String) async -> (isAvailable: Bool, errorMessage: String?) {
+    func checkEmail(_ email: String) async -> (success: Bool, data: Bool) {
         do {
-            let isAvailable = try await UserService.shared.fetchUserEmail(email: email)
-            return (isAvailable, nil)
+            let response = try await UserService.shared.fetchUserEmail(email: email)
+            return (response.success, response.data.isAvailable)
         } catch {
             Logger.log(.error, category: Logger.auth, message: "이메일 중복 검사 실패: \(error.localizedDescription)")
-            return (false, "이메일 중복 검사 실패: \(error.localizedDescription)")
+            return (false, false)
         }
     }
     

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -32,7 +32,7 @@ struct SignUpView: View {
                             Text(formatMessage)
                                 .font(.system(size: 14))
                                 .foregroundColor(.red)
-                                .frame(width: 330, alignment: .leading)
+                                .frame(width: 325, alignment: .leading)
                         }
 
                         if !viewModel.email.isEmpty, let emailCheck = viewModel.emailCheckMessage {
@@ -44,6 +44,15 @@ struct SignUpView: View {
                         
                         PasswordFieldView(title: "비밀번호", text: $viewModel.password, showPassword: $viewModel.showPassword)
                         
+                        PasswordFieldView(title: "비밀번호 확인", text: $viewModel.confirmPassword, showPassword: $viewModel.showPassword)
+                        
+                        if !viewModel.confirmPassword.isEmpty && viewModel.password != viewModel.confirmPassword {
+                            Text("비밀번호가 일치하지 않습니다.")
+                                .font(.system(size: 14))
+                                .foregroundColor(.red)
+                                .frame(width: 325, alignment: .leading)
+                        }
+                        
                         ValidatedInputField(
                             title: "닉네임",
                             text: $viewModel.nickname,
@@ -54,7 +63,7 @@ struct SignUpView: View {
                             Text(nicknameCheck)
                                 .font(.system(size: 14))
                                 .foregroundColor(nicknameCheck == "사용 가능한 닉네임입니다." ? .green : .red)
-                                .frame(width: 330, alignment: .leading)
+                                .frame(width: 325, alignment: .leading)
                                 .padding(.top, 1)
                         }
                         
@@ -81,7 +90,7 @@ struct SignUpView: View {
                             .clipShape(RoundedRectangle(cornerRadius: 12))
                         })
                         .padding(.top, 16)
-                        .disabled(!viewModel.isValid() || viewModel.isSigningUp)
+                        .disabled(!viewModel.isValid() || viewModel.isSigningUp || viewModel.password != viewModel.confirmPassword)
                         Spacer()
                     }
                     .padding(.bottom, 20)

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -155,12 +155,8 @@ struct SignUpView: View {
 struct InputFieldView: View {
     let title: String
     @Binding var text: String
-<<<<<<< HEAD
     var focus: FocusState<SignUpFocusField?>.Binding
     let field: SignUpFocusField
-=======
-    @FocusState private var isFocused: Bool
->>>>>>> origin/feature/refactor-signup
     
     var body: some View {
         VStack {
@@ -171,29 +167,15 @@ struct InputFieldView: View {
             .frame(width: 320, height: 25, alignment: .leading)
             
             TextField("", text: $text)
-<<<<<<< HEAD
                 .focused(focus, equals: field)
                 .frame(width: 300, height: 50)
                 .textInputAutocapitalization(.never)    // 첫 글자 대문자 표출 X
                 .frame(width: 330, height: 50)
-                .background(focus.wrappedValue == field ? Color("LoginBtnColor").opacity(0.06) : .clear)
                 .overlay {
                     RoundedRectangle(cornerRadius: 12)
                         .stroke(focus.wrappedValue == field ? Color("LoginBtnColor") : Color("FontColor"),
                                 lineWidth: focus.wrappedValue == field ? 1.2 : 0.6)
                         .animation(.easeInOut(duration: 0.15), value: focus.wrappedValue == field)
-=======
-                .focused($isFocused)
-                .frame(width: 300, height: 50)
-                .textInputAutocapitalization(.never)    // 첫 글자 대문자 표출 X
-                .frame(width: 330, height: 50)
-                .background(isFocused ? Color("LoginBtnColor").opacity(0.06) : .clear)
-                .overlay {
-                    RoundedRectangle(cornerRadius: 12)
-                        .stroke(isFocused ? Color("LoginBtnColor") : Color("FontColor"),
-                                lineWidth: isFocused ? 1.2 : 0.6)
-                        .animation(.easeInOut(duration: 0.15), value: isFocused)
->>>>>>> origin/feature/refactor-signup
                 }
         }
         .frame(width: 330, height: 90)
@@ -204,12 +186,8 @@ struct PasswordFieldView: View {
     let title: String
     @Binding var text: String
     @Binding var showPassword: Bool
-<<<<<<< HEAD
     var focus: FocusState<SignUpFocusField?>.Binding
     let field: SignUpFocusField
-=======
-    @FocusState private var isFocused: Bool
->>>>>>> origin/feature/refactor-signup
     
     var body: some View {
         VStack {
@@ -227,21 +205,14 @@ struct PasswordFieldView: View {
                 Section {
                     if showPassword {
                         TextField("", text: $text)
-<<<<<<< HEAD
                             .focused(focus, equals: field)
-=======
-                            .focused($isFocused)
->>>>>>> origin/feature/refactor-signup
                             .onChange(of: text) { newValue, _ in
                                 if newValue.count > 20 { text = String(newValue.prefix(20)) }
                             }
                     } else {
                         SecureField("", text: $text)
-<<<<<<< HEAD
                             .focused(focus, equals: field)
-=======
-                            .focused($isFocused)
->>>>>>> origin/feature/refactor-signup
+
                             .onChange(of: text) { newValue, _ in
                                 if newValue.count > 20 { text = String(newValue.prefix(20)) }
                             }
@@ -259,20 +230,11 @@ struct PasswordFieldView: View {
                 })
             }
             .frame(width: 330, height: 50)
-<<<<<<< HEAD
-            .background(focus.wrappedValue == field ? Color("LoginBtnColor").opacity(0.06) : .clear)
             .overlay {
                 RoundedRectangle(cornerRadius: 13)
                     .stroke(focus.wrappedValue == field ? Color("LoginBtnColor") : Color("FontColor"),
                             lineWidth: focus.wrappedValue == field ? 1.2 : 0.6)
-=======
-            .background(isFocused ? Color("LoginBtnColor").opacity(0.06) : .clear)
-            .overlay {
-                RoundedRectangle(cornerRadius: 13)
-                    .stroke(isFocused ? Color("LoginBtnColor") : Color("FontColor"),
-                            lineWidth: isFocused ? 1.2 : 0.6)
-                    .animation(.easeInOut(duration: 0.15), value: isFocused)
->>>>>>> origin/feature/refactor-signup
+                    .animation(.easeInOut(duration: 0.1), value: focus.wrappedValue == field)
             }
         }
         .frame(width: 330, height: 90)
@@ -313,12 +275,8 @@ struct ValidatedInputField: View {
     let title: String
     @Binding var text: String
     let onCheckDuplicate: () async -> Void
-<<<<<<< HEAD
     var focus: FocusState<SignUpFocusField?>.Binding
     let field: SignUpFocusField
-=======
-    @FocusState private var isFocused: Bool
->>>>>>> origin/feature/refactor-signup
 
     var body: some View {
         VStack {
@@ -334,27 +292,14 @@ struct ValidatedInputField: View {
 
             HStack {
                 TextField("", text: $text)
-<<<<<<< HEAD
                     .focused(focus, equals: field)
                     .frame(width: 210, height: 50)
                     .textInputAutocapitalization(.never)
                     .frame(width: 240, height: 50)
-                    .background(focus.wrappedValue == field ? Color("LoginBtnColor").opacity(0.06) : .clear)
                     .overlay {
                         RoundedRectangle(cornerRadius: 12)
                             .stroke(focus.wrappedValue == field ? Color("LoginBtnColor") : Color("FontColor"), lineWidth: focus.wrappedValue == field ? 1.2 : 0.6)
-                            .animation(.easeInOut(duration: 0.15), value: focus.wrappedValue == field)
-=======
-                    .focused($isFocused)
-                    .frame(width: 210, height: 50)
-                    .textInputAutocapitalization(.never)
-                    .frame(width: 240, height: 50)
-                    .background(isFocused ? Color("LoginBtnColor").opacity(0.06) : .clear)
-                    .overlay {
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(isFocused ? Color("LoginBtnColor") : Color("FontColor"), lineWidth: isFocused ? 1.2 : 0.6)
-                            .animation(.easeInOut(duration: 0.15), value: isFocused)
->>>>>>> origin/feature/refactor-signup
+                            .animation(.easeInOut(duration: 0.1), value: focus.wrappedValue == field)
                     }
 
                 Button("중복 확인") {

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -142,6 +142,7 @@ struct SignUpView: View {
 struct InputFieldView: View {
     let title: String
     @Binding var text: String
+    @FocusState private var isFocused: Bool
     
     var body: some View {
         VStack {
@@ -152,12 +153,16 @@ struct InputFieldView: View {
             .frame(width: 320, height: 25, alignment: .leading)
             
             TextField("", text: $text)
+                .focused($isFocused)
                 .frame(width: 300, height: 50)
                 .textInputAutocapitalization(.never)    // 첫 글자 대문자 표출 X
                 .frame(width: 330, height: 50)
-                .overlay() {
+                .background(isFocused ? Color("LoginBtnColor").opacity(0.06) : .clear)
+                .overlay {
                     RoundedRectangle(cornerRadius: 12)
-                        .stroke(Color("FontColor"), lineWidth: 0.6)
+                        .stroke(isFocused ? Color("LoginBtnColor") : Color("FontColor"),
+                                lineWidth: isFocused ? 1.2 : 0.6)
+                        .animation(.easeInOut(duration: 0.15), value: isFocused)
                 }
         }
         .frame(width: 330, height: 90)
@@ -168,6 +173,7 @@ struct PasswordFieldView: View {
     let title: String
     @Binding var text: String
     @Binding var showPassword: Bool
+    @FocusState private var isFocused: Bool
     
     var body: some View {
         VStack {
@@ -185,8 +191,16 @@ struct PasswordFieldView: View {
                 Section {
                     if showPassword {
                         TextField("", text: $text)
+                            .focused($isFocused)
+                            .onChange(of: text) { newValue, _ in
+                                if newValue.count > 20 { text = String(newValue.prefix(20)) }
+                            }
                     } else {
                         SecureField("", text: $text)
+                            .focused($isFocused)
+                            .onChange(of: text) { newValue, _ in
+                                if newValue.count > 20 { text = String(newValue.prefix(20)) }
+                            }
                     }
                 }
                 .frame(width: 260, height: 40)
@@ -201,9 +215,12 @@ struct PasswordFieldView: View {
                 })
             }
             .frame(width: 330, height: 50)
+            .background(isFocused ? Color("LoginBtnColor").opacity(0.06) : .clear)
             .overlay {
                 RoundedRectangle(cornerRadius: 13)
-                    .stroke(Color("FontColor"), lineWidth: 0.6)
+                    .stroke(isFocused ? Color("LoginBtnColor") : Color("FontColor"),
+                            lineWidth: isFocused ? 1.2 : 0.6)
+                    .animation(.easeInOut(duration: 0.15), value: isFocused)
             }
         }
         .frame(width: 330, height: 90)
@@ -244,6 +261,7 @@ struct ValidatedInputField: View {
     let title: String
     @Binding var text: String
     let onCheckDuplicate: () async -> Void
+    @FocusState private var isFocused: Bool
 
     var body: some View {
         VStack {
@@ -259,12 +277,15 @@ struct ValidatedInputField: View {
 
             HStack {
                 TextField("", text: $text)
+                    .focused($isFocused)
                     .frame(width: 210, height: 50)
                     .textInputAutocapitalization(.never)
                     .frame(width: 240, height: 50)
+                    .background(isFocused ? Color("LoginBtnColor").opacity(0.06) : .clear)
                     .overlay {
                         RoundedRectangle(cornerRadius: 12)
-                            .stroke(Color("FontColor"), lineWidth: 0.6)
+                            .stroke(isFocused ? Color("LoginBtnColor") : Color("FontColor"), lineWidth: isFocused ? 1.2 : 0.6)
+                            .animation(.easeInOut(duration: 0.15), value: isFocused)
                     }
 
                 Button("중복 확인") {

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -115,6 +115,7 @@ struct SignUpView: View {
                     }
                     .padding(.bottom, 20)
                 }
+                .scrollIndicators(.hidden)
                 .padding(.horizontal)
             }
             .navigationBarTitleDisplayMode(.inline)

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -7,14 +7,9 @@
 
 import SwiftUI
 
-enum SignUpField: Hashable {
-    case email, nickname
-}
-
 struct SignUpView: View {
     @State private var viewModel = SignUpViewModel()
     @Environment(\.dismiss) private var dismiss
-    @FocusState private var focusedField: SignUpField?
     var onSignUpSuccess: (() -> Void)? = nil
 
     var body: some View {
@@ -30,22 +25,17 @@ struct SignUpView: View {
                         ValidatedInputField(
                             title: "이메일",
                             text: $viewModel.email,
-                            focusTag: .email,
-                            focusedField: $focusedField,
-                            submitLabel: .next,
-                            onSubmit: {
-                                Task {
-                                    
-                                }
-                            }
+                            onCheckDuplicate: { await viewModel.checkValidateEmail() }
                         )
                         
                         if let emailError = viewModel.emailErrorMessage {
                             Text(emailError)
                                 .font(.system(size: 14))
                                 .foregroundColor(.red)
-                                .frame(width: 320, height: 20, alignment: .leading)
-                        } else if let emailCheck = viewModel.emailCheckMessage {
+                                .frame(width: 330, alignment: .leading)
+                        }
+                        
+                        if !viewModel.email.isEmpty, let emailCheck = viewModel.emailCheckMessage {
                             Text(emailCheck)
                                 .font(.system(size: 14))
                                 .foregroundColor(emailCheck == "사용 가능한 이메일입니다." ? .green : .red)
@@ -57,14 +47,7 @@ struct SignUpView: View {
                         ValidatedInputField(
                             title: "닉네임",
                             text: $viewModel.nickname,
-                            focusTag: .nickname,
-                            focusedField: $focusedField,
-                            submitLabel: .next,
-                            onSubmit: {
-                                Task {
-                                    //
-                                }
-                            }
+                            onCheckDuplicate: { await viewModel.checkValidateNickname() }
                         )
                         
                         if let nicknameError = viewModel.nicknameErrorMessage {
@@ -191,6 +174,7 @@ struct PasswordFieldView: View {
                     }
                 }
                 .frame(width: 260, height: 40)
+                .textInputAutocapitalization(.never)
                 
                 Button(action: {
                     self.showPassword.toggle()
@@ -240,13 +224,10 @@ struct GenderSelectedView: View {
     }
 }
 
-struct ValidatedInputField<Field: Hashable>: View {
+struct ValidatedInputField: View {
     let title: String
     @Binding var text: String
-    let focusTag: Field
-    @FocusState.Binding var focusedField: Field?
-    let submitLabel: SubmitLabel
-    let onSubmit: (() -> Void)?
+    let onCheckDuplicate: () async -> Void
 
     var body: some View {
         VStack {
@@ -260,19 +241,29 @@ struct ValidatedInputField<Field: Hashable>: View {
             }
             .frame(width: 320, height: 25, alignment: .leading)
 
-            TextField("", text: $text)
-                .focused($focusedField, equals: focusTag)
-                .submitLabel(submitLabel)
-                .onSubmit {
-                    onSubmit?()
+            HStack {
+                TextField("", text: $text)
+                    .frame(width: 210, height: 50)
+                    .textInputAutocapitalization(.never)
+                    .frame(width: 240, height: 50)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color("FontColor"), lineWidth: 0.6)
+                    }
+
+                Button("중복 확인") {
+                    Task {
+                        await onCheckDuplicate()
+                    }
                 }
-                .frame(width: 300, height: 50)
-                .textInputAutocapitalization(.never)
-                .frame(width: 330, height: 50)
-                .overlay {
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(CHColors.Button.primary)
+                .frame(width: 80, height: 50)
+                .overlay(
                     RoundedRectangle(cornerRadius: 12)
-                        .stroke(Color("FontColor"), lineWidth: 0.6)
-                }
+                        .stroke(CHColors.Button.primary, lineWidth: 1)
+                )
+            }
         }
         .frame(width: 330, height: 90)
     }

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -7,9 +7,18 @@
 
 import SwiftUI
 
+enum SignUpFocusField: Hashable {
+    case email
+    case password
+    case confirmPassword
+    case nickname
+    case name
+}
+
 struct SignUpView: View {
     @State private var viewModel = SignUpViewModel()
     @Environment(\.dismiss) private var dismiss
+    @FocusState private var focusedField: SignUpFocusField?
     var onSignUpSuccess: (() -> Void)? = nil
 
     var body: some View {
@@ -25,7 +34,9 @@ struct SignUpView: View {
                         ValidatedInputField(
                             title: "이메일",
                             text: $viewModel.email,
-                            onCheckDuplicate: { await viewModel.checkEmailWithFormatValidation() }
+                            onCheckDuplicate: { await viewModel.checkEmailWithFormatValidation() },
+                            focus: $focusedField,
+                            field: .email
                         )
 
                         if let formatMessage = viewModel.emailFormatInvalidMessage {
@@ -42,18 +53,18 @@ struct SignUpView: View {
                                 .frame(width: 330, alignment: .leading)
                         }
                         
-                        PasswordFieldView(title: "비밀번호", text: $viewModel.password, showPassword: $viewModel.showPassword)
+                        PasswordFieldView(title: "비밀번호", text: $viewModel.password, showPassword: $viewModel.showPassword, focus: $focusedField, field: .password)
                         
-                        if let errorMessage = viewModel.passwordErrorMessage {
+                        if focusedField != .password, let errorMessage = viewModel.passwordErrorMessage {
                             Text(errorMessage)
                                 .font(.system(size: 14))
                                 .foregroundColor(.red)
                                 .frame(width: 325, alignment: .leading)
                         }
                         
-                        PasswordFieldView(title: "비밀번호 확인", text: $viewModel.confirmPassword, showPassword: $viewModel.showPassword)
+                        PasswordFieldView(title: "비밀번호 확인", text: $viewModel.confirmPassword, showPassword: $viewModel.showPassword, focus: $focusedField, field: .confirmPassword)
                         
-                        if !viewModel.confirmPassword.isEmpty && viewModel.password != viewModel.confirmPassword {
+                        if focusedField != .confirmPassword, !viewModel.confirmPassword.isEmpty && viewModel.password != viewModel.confirmPassword {
                             Text("비밀번호가 일치하지 않습니다.")
                                 .font(.system(size: 14))
                                 .foregroundColor(.red)
@@ -63,7 +74,9 @@ struct SignUpView: View {
                         ValidatedInputField(
                             title: "닉네임",
                             text: $viewModel.nickname,
-                            onCheckDuplicate: { await viewModel.checkValidateNickname() }
+                            onCheckDuplicate: { await viewModel.checkValidateNickname() },
+                            focus: $focusedField,
+                            field: .nickname
                         )
                         
                         if let nicknameCheck = viewModel.nicknameCheckMessage {
@@ -74,7 +87,7 @@ struct SignUpView: View {
                                 .padding(.top, 1)
                         }
                         
-                        InputFieldView(title: "이름", text: $viewModel.name)
+                        InputFieldView(title: "이름", text: $viewModel.name, focus: $focusedField, field: .name)
                         GenderSelectedView(selectedGender: $viewModel.gender)
                         
                         Button(action: {
@@ -142,7 +155,8 @@ struct SignUpView: View {
 struct InputFieldView: View {
     let title: String
     @Binding var text: String
-    @FocusState private var isFocused: Bool
+    var focus: FocusState<SignUpFocusField?>.Binding
+    let field: SignUpFocusField
     
     var body: some View {
         VStack {
@@ -153,16 +167,16 @@ struct InputFieldView: View {
             .frame(width: 320, height: 25, alignment: .leading)
             
             TextField("", text: $text)
-                .focused($isFocused)
+                .focused(focus, equals: field)
                 .frame(width: 300, height: 50)
                 .textInputAutocapitalization(.never)    // 첫 글자 대문자 표출 X
                 .frame(width: 330, height: 50)
-                .background(isFocused ? Color("LoginBtnColor").opacity(0.06) : .clear)
+                .background(focus.wrappedValue == field ? Color("LoginBtnColor").opacity(0.06) : .clear)
                 .overlay {
                     RoundedRectangle(cornerRadius: 12)
-                        .stroke(isFocused ? Color("LoginBtnColor") : Color("FontColor"),
-                                lineWidth: isFocused ? 1.2 : 0.6)
-                        .animation(.easeInOut(duration: 0.15), value: isFocused)
+                        .stroke(focus.wrappedValue == field ? Color("LoginBtnColor") : Color("FontColor"),
+                                lineWidth: focus.wrappedValue == field ? 1.2 : 0.6)
+                        .animation(.easeInOut(duration: 0.15), value: focus.wrappedValue == field)
                 }
         }
         .frame(width: 330, height: 90)
@@ -173,7 +187,8 @@ struct PasswordFieldView: View {
     let title: String
     @Binding var text: String
     @Binding var showPassword: Bool
-    @FocusState private var isFocused: Bool
+    var focus: FocusState<SignUpFocusField?>.Binding
+    let field: SignUpFocusField
     
     var body: some View {
         VStack {
@@ -191,13 +206,13 @@ struct PasswordFieldView: View {
                 Section {
                     if showPassword {
                         TextField("", text: $text)
-                            .focused($isFocused)
+                            .focused(focus, equals: field)
                             .onChange(of: text) { newValue, _ in
                                 if newValue.count > 20 { text = String(newValue.prefix(20)) }
                             }
                     } else {
                         SecureField("", text: $text)
-                            .focused($isFocused)
+                            .focused(focus, equals: field)
                             .onChange(of: text) { newValue, _ in
                                 if newValue.count > 20 { text = String(newValue.prefix(20)) }
                             }
@@ -215,12 +230,11 @@ struct PasswordFieldView: View {
                 })
             }
             .frame(width: 330, height: 50)
-            .background(isFocused ? Color("LoginBtnColor").opacity(0.06) : .clear)
+            .background(focus.wrappedValue == field ? Color("LoginBtnColor").opacity(0.06) : .clear)
             .overlay {
                 RoundedRectangle(cornerRadius: 13)
-                    .stroke(isFocused ? Color("LoginBtnColor") : Color("FontColor"),
-                            lineWidth: isFocused ? 1.2 : 0.6)
-                    .animation(.easeInOut(duration: 0.15), value: isFocused)
+                    .stroke(focus.wrappedValue == field ? Color("LoginBtnColor") : Color("FontColor"),
+                            lineWidth: focus.wrappedValue == field ? 1.2 : 0.6)
             }
         }
         .frame(width: 330, height: 90)
@@ -261,7 +275,8 @@ struct ValidatedInputField: View {
     let title: String
     @Binding var text: String
     let onCheckDuplicate: () async -> Void
-    @FocusState private var isFocused: Bool
+    var focus: FocusState<SignUpFocusField?>.Binding
+    let field: SignUpFocusField
 
     var body: some View {
         VStack {
@@ -277,15 +292,15 @@ struct ValidatedInputField: View {
 
             HStack {
                 TextField("", text: $text)
-                    .focused($isFocused)
+                    .focused(focus, equals: field)
                     .frame(width: 210, height: 50)
                     .textInputAutocapitalization(.never)
                     .frame(width: 240, height: 50)
-                    .background(isFocused ? Color("LoginBtnColor").opacity(0.06) : .clear)
+                    .background(focus.wrappedValue == field ? Color("LoginBtnColor").opacity(0.06) : .clear)
                     .overlay {
                         RoundedRectangle(cornerRadius: 12)
-                            .stroke(isFocused ? Color("LoginBtnColor") : Color("FontColor"), lineWidth: isFocused ? 1.2 : 0.6)
-                            .animation(.easeInOut(duration: 0.15), value: isFocused)
+                            .stroke(focus.wrappedValue == field ? Color("LoginBtnColor") : Color("FontColor"), lineWidth: focus.wrappedValue == field ? 1.2 : 0.6)
+                            .animation(.easeInOut(duration: 0.15), value: focus.wrappedValue == field)
                     }
 
                 Button("중복 확인") {

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -44,6 +44,13 @@ struct SignUpView: View {
                         
                         PasswordFieldView(title: "비밀번호", text: $viewModel.password, showPassword: $viewModel.showPassword)
                         
+                        if let errorMessage = viewModel.passwordErrorMessage {
+                            Text(errorMessage)
+                                .font(.system(size: 14))
+                                .foregroundColor(.red)
+                                .frame(width: 325, alignment: .leading)
+                        }
+                        
                         PasswordFieldView(title: "비밀번호 확인", text: $viewModel.confirmPassword, showPassword: $viewModel.showPassword)
                         
                         if !viewModel.confirmPassword.isEmpty && viewModel.password != viewModel.confirmPassword {

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -25,16 +25,16 @@ struct SignUpView: View {
                         ValidatedInputField(
                             title: "이메일",
                             text: $viewModel.email,
-                            onCheckDuplicate: { await viewModel.checkValidateEmail() }
+                            onCheckDuplicate: { await viewModel.checkEmailWithFormatValidation() }
                         )
-                        
-                        if let emailError = viewModel.emailErrorMessage {
-                            Text(emailError)
+
+                        if let formatMessage = viewModel.emailFormatInvalidMessage {
+                            Text(formatMessage)
                                 .font(.system(size: 14))
                                 .foregroundColor(.red)
                                 .frame(width: 330, alignment: .leading)
                         }
-                        
+
                         if !viewModel.email.isEmpty, let emailCheck = viewModel.emailCheckMessage {
                             Text(emailCheck)
                                 .font(.system(size: 14))
@@ -50,10 +50,10 @@ struct SignUpView: View {
                             onCheckDuplicate: { await viewModel.checkValidateNickname() }
                         )
                         
-                        if let nicknameError = viewModel.nicknameErrorMessage {
-                            Text(nicknameError)
+                        if let nicknameCheck = viewModel.nicknameCheckMessage {
+                            Text(nicknameCheck)
                                 .font(.system(size: 14))
-                                .foregroundColor(nicknameError == "사용 가능한 닉네임입니다." ? .green : .red)
+                                .foregroundColor(nicknameCheck == "사용 가능한 닉네임입니다." ? .green : .red)
                                 .frame(width: 330, alignment: .leading)
                                 .padding(.top, 1)
                         }

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -288,6 +288,16 @@ struct ValidatedInputField: View {
     let field: SignUpFocusField
 
     var body: some View {
+        let maxLength: Int = {
+            switch field {
+            case .email:
+                return 50
+            case .nickname:
+                return 12
+            default:
+                return 30
+            }
+        }()
         VStack {
             HStack {
                 Text(title)
@@ -302,6 +312,11 @@ struct ValidatedInputField: View {
             HStack {
                 TextField("", text: $text)
                     .focused(focus, equals: field)
+                    .onChange(of: text) { newValue, _ in
+                        if newValue.count > maxLength {
+                            text = String(newValue.prefix(maxLength))
+                        }
+                    }
                     .frame(width: 210, height: 50)
                     .textInputAutocapitalization(.never)
                     .frame(width: 240, height: 50)

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -7,11 +7,16 @@
 
 import SwiftUI
 
+enum SignUpField: Hashable {
+    case email, nickname
+}
+
 struct SignUpView: View {
     @State private var viewModel = SignUpViewModel()
     @Environment(\.dismiss) private var dismiss
+    @FocusState private var focusedField: SignUpField?
     var onSignUpSuccess: (() -> Void)? = nil
-    
+
     var body: some View {
         NavigationStack {
             VStack {
@@ -22,7 +27,18 @@ struct SignUpView: View {
                             .font(.system(size: 22, weight: .bold))
                             .padding(.horizontal, 16)
                         
-                        InputFieldView(title: "이메일", text: $viewModel.email)
+                        ValidatedInputField(
+                            title: "이메일",
+                            text: $viewModel.email,
+                            focusTag: .email,
+                            focusedField: $focusedField,
+                            submitLabel: .next,
+                            onSubmit: {
+                                Task {
+                                    
+                                }
+                            }
+                        )
                         
                         if let emailError = viewModel.emailErrorMessage {
                             Text(emailError)
@@ -37,7 +53,19 @@ struct SignUpView: View {
                         }
                         
                         PasswordFieldView(title: "비밀번호", text: $viewModel.password, showPassword: $viewModel.showPassword)
-                        InputFieldView(title: "닉네임", text: $viewModel.nickname)
+                        
+                        ValidatedInputField(
+                            title: "닉네임",
+                            text: $viewModel.nickname,
+                            focusTag: .nickname,
+                            focusedField: $focusedField,
+                            submitLabel: .next,
+                            onSubmit: {
+                                Task {
+                                    //
+                                }
+                            }
+                        )
                         
                         if let nicknameError = viewModel.nicknameErrorMessage {
                             Text(nicknameError)
@@ -47,7 +75,7 @@ struct SignUpView: View {
                                 .padding(.top, 1)
                         }
                         
-                        InputFieldView(title: "이름", text: $viewModel.name, isRequired: false)
+                        InputFieldView(title: "이름", text: $viewModel.name)
                         GenderSelectedView(selectedGender: $viewModel.gender)
                         
                         Button(action: {
@@ -115,20 +143,12 @@ struct SignUpView: View {
 struct InputFieldView: View {
     let title: String
     @Binding var text: String
-    var isRequired: Bool = true
     
     var body: some View {
         VStack {
             HStack {
                 Text(title)
                     .font(.system(size: 17))
-                // isRequired가 true일 때만 * 표시
-                if isRequired {
-                    Text("*")
-                        .font(.system(size: 20))
-                        .foregroundStyle(.red)
-                        .offset(x: -7)
-                }
             }
             .frame(width: 320, height: 25, alignment: .leading)
             
@@ -215,6 +235,44 @@ struct GenderSelectedView: View {
                     )
                 }
             }
+        }
+        .frame(width: 330, height: 90)
+    }
+}
+
+struct ValidatedInputField<Field: Hashable>: View {
+    let title: String
+    @Binding var text: String
+    let focusTag: Field
+    @FocusState.Binding var focusedField: Field?
+    let submitLabel: SubmitLabel
+    let onSubmit: (() -> Void)?
+
+    var body: some View {
+        VStack {
+            HStack {
+                Text(title)
+                    .font(.system(size: 17))
+                Text("*")
+                    .font(.system(size: 20))
+                    .foregroundStyle(.red)
+                    .offset(x: -7)
+            }
+            .frame(width: 320, height: 25, alignment: .leading)
+
+            TextField("", text: $text)
+                .focused($focusedField, equals: focusTag)
+                .submitLabel(submitLabel)
+                .onSubmit {
+                    onSubmit?()
+                }
+                .frame(width: 300, height: 50)
+                .textInputAutocapitalization(.never)
+                .frame(width: 330, height: 50)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color("FontColor"), lineWidth: 0.6)
+                }
         }
         .frame(width: 330, height: 90)
     }

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -168,6 +168,11 @@ struct InputFieldView: View {
             
             TextField("", text: $text)
                 .focused(focus, equals: field)
+                .onChange(of: text){ newValue, _ in
+                    if newValue.count > 20 {
+                        text = String(newValue.prefix(20))
+                    }
+                }
                 .frame(width: 300, height: 50)
                 .textInputAutocapitalization(.never)    // 첫 글자 대문자 표출 X
                 .frame(width: 330, height: 50)

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -254,7 +254,11 @@ struct GenderSelectedView: View {
             HStack {
                 ForEach(genders, id: \.self) { gender in
                     Button(action: {
-                        selectedGender = gender
+                        if selectedGender == gender {
+                            selectedGender = ""
+                        } else {
+                            selectedGender = gender
+                        }
                     }) {
                         Text(gender)
                             .foregroundColor(selectedGender == gender ? Color("LoginBtnColor") : Color("FontColor"))

--- a/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
@@ -10,31 +10,18 @@ import Foundation
 @Observable
 class SignUpViewModel {
     // 사용자 입력 데이터
-    var email: String = "" {
-        didSet {
-            validateEmail()
-        }
-    }
+    var email: String = ""
     var password: String = ""
-    var nickname: String = "" {
-        didSet {
-            if nickname.count >= 1 {
-                Task {
-                    await checkValidateNickname()
-                }
-            } else {
-                nicknameErrorMessage = nil
-            }
-        }
-    }
     var name: String = ""
+    var nickname: String = ""
     var gender: String = ""
+    var genres: [String] = []
     var showPassword: Bool = false
     
     // 상태 및 오류 메시지
-    var emailErrorMessage: String? = nil
-    var nicknameErrorMessage: String? = nil
+    var emailFormatInvalidMessage: String? = nil
     var nicknameAvailable: Bool = false
+    var nicknameCheckMessage: String? = nil
     var emailAvailable: Bool = false
     var emailCheckMessage: String? = nil
     var isSignUpSuccess: Bool = false
@@ -50,18 +37,8 @@ class SignUpViewModel {
     // 이메일 정규식 검사 함수
     func isValidEmail(_ email: String) -> Bool {
         let emailRegex = #"^[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$"#
-        return NSPredicate(format: "SELF MATCHES %@", emailRegex).evaluate(with: email)
-    }
-    
-    // 이메일 검사 후 오류 메시지 업데이트
-    func validateEmail() {
-        if email.isEmpty {
-            emailErrorMessage = nil
-        } else if !isValidEmail(email) {
-            emailErrorMessage = "이메일의 형식이 맞지 않습니다."
-        } else {
-            emailErrorMessage = nil
-        }
+        let isValid = NSPredicate(format: "SELF MATCHES %@", emailRegex).evaluate(with: email)
+        return isValid
     }
     
     // 이메일 중복 검사
@@ -72,29 +49,36 @@ class SignUpViewModel {
         if isAvailable {
             self.emailCheckMessage = "사용 가능한 이메일입니다."
             self.emailAvailable = true
-        }else {
+        } else {
             self.emailCheckMessage = "이미 사용 중인 이메일입니다."
             self.emailAvailable = false
+        }
+    }
+
+    // 이메일 형식 검사 후 중복 검사
+    @MainActor
+    func checkEmailWithFormatValidation() async {
+        if isValidEmail(email) {
+            emailFormatInvalidMessage = nil
+            await checkValidateEmail()
+        } else {
+            emailCheckMessage = nil
+            emailFormatInvalidMessage = "이메일의 형식이 맞지 않습니다."
         }
     }
     
     // 닉네임 중복 검사
     @MainActor
     func checkValidateNickname() async {
-//        let (isAvailable, error) = await UserState.shared.checkNickname(nickname)
-//        
-//        if let error = error {
-//            self.nicknameErrorMessage = error
-//            self.nicknameAvailable = false
-//        } else {
-//            if isAvailable {
-//                self.nicknameErrorMessage = "사용 가능한 닉네임입니다."
-//                self.nicknameAvailable = true
-//            } else {
-//                self.nicknameErrorMessage = "이미 사용 중인 닉네임입니다."
-//                self.nicknameAvailable = false
-//            }
-//        }
+        let (_, isAvailable) = await UserState.shared.checkNickname(nickname)
+        
+        if isAvailable {
+            self.nicknameCheckMessage = "사용 가능한 닉네임입니다."
+            self.nicknameAvailable = true
+        }else {
+            self.emailCheckMessage = "이미 사용 중인 닉네임입니다."
+            self.nicknameAvailable = false
+        }
     }
     
     // 회원가입

--- a/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
@@ -102,14 +102,15 @@ class SignUpViewModel {
     func signUp() async {
         isSigningUp = true
         generalErrorMessage = nil
+        let convertedGender = (gender == "남자") ? "MALE" : "FEMALE"
         
-        let newUser = User(
+        let newUser = SignUpRequest(
             email: email,
             password: password,
+            name: name,
             nickname: nickname,
-            name: name.isEmpty ? nil : name,
-            gender: gender.isEmpty ? nil : gender,
-            type: "일반"
+            gender: convertedGender,
+            genres: genres
         )
         
         let success = await UserState.shared.signUp(user: newUser)

--- a/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
@@ -12,6 +12,7 @@ class SignUpViewModel {
     // 사용자 입력 데이터
     var email: String = ""
     var password: String = ""
+    var confirmPassword: String = ""
     var name: String = ""
     var nickname: String = ""
     var gender: String = ""
@@ -30,7 +31,7 @@ class SignUpViewModel {
     
     // 필수 필드 채워져 있는지 검사 및 중복검사 결과에 따른 회원가입 버튼 활성화
     func isValid() -> Bool {
-        return !email.isEmpty && !password.isEmpty && !nickname.isEmpty &&
+        return !email.isEmpty && !password.isEmpty && !confirmPassword.isEmpty && !nickname.isEmpty &&
                isValidEmail(email) && nicknameAvailable && emailAvailable
     }
     
@@ -91,6 +92,7 @@ class SignUpViewModel {
         let newUser = SignUpRequest(
             email: email,
             password: password,
+            confirmPassword: confirmPassword,
             name: name,
             nickname: nickname,
             gender: convertedGender,

--- a/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
@@ -12,11 +12,6 @@ class SignUpViewModel {
     // 사용자 입력 데이터
     var email: String = "" {
         didSet {
-            if isValidEmail(email) {
-                Task {
-                    await checkValidateEmail()
-                }
-            }
             validateEmail()
         }
     }

--- a/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
@@ -7,6 +7,16 @@
 
 import Foundation
 
+enum PasswordValidationError: String {
+    case space = "공백 문자는 사용할 수 없습니다."
+    case length = "비밀번호는 8~20자여야 합니다."
+    case upper = "대문자를 최소 1개 포함해야 합니다."
+    case lower = "소문자를 최소 1개 포함해야 합니다."
+    case digit = "숫자를 최소 1개 포함해야 합니다."
+    case special = "특수문자를 최소 1개 포함해야 합니다."
+}
+
+
 @Observable
 class SignUpViewModel {
     // 사용자 입력 데이터
@@ -32,7 +42,35 @@ class SignUpViewModel {
     // 필수 필드 채워져 있는지 검사 및 중복검사 결과에 따른 회원가입 버튼 활성화
     func isValid() -> Bool {
         return !email.isEmpty && !password.isEmpty && !confirmPassword.isEmpty && !nickname.isEmpty &&
-               isValidEmail(email) && nicknameAvailable && emailAvailable
+        isValidEmail(email) && isValidPassword(password).0 &&
+               nicknameAvailable && emailAvailable
+    }
+    
+    // 비밀번호 유효성 검사: 영문 대소문자, 숫자, 특수문자 포함 8~20자, 공백 불가
+    func isValidPassword(_ password: String) -> (Bool, PasswordValidationError?) {
+        if password.contains(where: { $0.isWhitespace }) {
+            return (false, .space)
+        }
+        if password.count < 8 || password.count > 20 {
+            return (false, .length)
+        }
+        if password.range(of: "[A-Z]", options: .regularExpression) == nil {
+            return (false, .upper)
+        }
+        if password.range(of: "[a-z]", options: .regularExpression) == nil {
+            return (false, .lower)
+        }
+        if password.range(of: "[0-9]", options: .regularExpression) == nil {
+            return (false, .digit)
+        }
+        if password.range(of: "[!@#$%^&*(),.?\":{}|<>]", options: .regularExpression) == nil {
+            return (false, .special)
+        }
+        return (true, nil)
+    }
+    
+    var passwordErrorMessage: String? {
+        return isValidPassword(password).1?.rawValue
     }
     
     // 이메일 정규식 검사 함수

--- a/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
@@ -20,7 +20,7 @@ class SignUpViewModel {
         didSet {
             if nickname.count >= 1 {
                 Task {
-                    await validateNickname()
+                    await checkValidateNickname()
                 }
             } else {
                 nicknameErrorMessage = nil
@@ -67,39 +67,34 @@ class SignUpViewModel {
     // 이메일 중복 검사
     @MainActor
     func checkValidateEmail() async {
-        let (isAvailable, error) = await UserState.shared.checkEmail(email)
+        let (_, isAvailable) = await UserState.shared.checkEmail(email)
         
-        if let error = error {
-            self.emailErrorMessage = error
+        if isAvailable {
+            self.emailCheckMessage = "사용 가능한 이메일입니다."
+            self.emailAvailable = true
+        }else {
+            self.emailCheckMessage = "이미 사용 중인 이메일입니다."
             self.emailAvailable = false
-        } else {
-            if isAvailable {
-                self.emailCheckMessage = "사용 가능한 이메일입니다."
-                self.emailAvailable = true
-            } else {
-                self.emailCheckMessage = "이미 사용 중인 이메일입니다."
-                self.emailAvailable = false
-            }
         }
     }
     
     // 닉네임 중복 검사
     @MainActor
-    func validateNickname() async {
-        let (isAvailable, error) = await UserState.shared.checkNickname(nickname)
-        
-        if let error = error {
-            self.nicknameErrorMessage = error
-            self.nicknameAvailable = false
-        } else {
-            if isAvailable {
-                self.nicknameErrorMessage = "사용 가능한 닉네임입니다."
-                self.nicknameAvailable = true
-            } else {
-                self.nicknameErrorMessage = "이미 사용 중인 닉네임입니다."
-                self.nicknameAvailable = false
-            }
-        }
+    func checkValidateNickname() async {
+//        let (isAvailable, error) = await UserState.shared.checkNickname(nickname)
+//        
+//        if let error = error {
+//            self.nicknameErrorMessage = error
+//            self.nicknameAvailable = false
+//        } else {
+//            if isAvailable {
+//                self.nicknameErrorMessage = "사용 가능한 닉네임입니다."
+//                self.nicknameAvailable = true
+//            } else {
+//                self.nicknameErrorMessage = "이미 사용 중인 닉네임입니다."
+//                self.nicknameAvailable = false
+//            }
+//        }
     }
     
     // 회원가입

--- a/CineHive/CineHive/Resources/Dummy/User+Dummy.swift
+++ b/CineHive/CineHive/Resources/Dummy/User+Dummy.swift
@@ -10,13 +10,12 @@ import Foundation
 extension User {
     static var dummy1: User {
         User(
-            id: 1,
             email: "unib335@naver.com",
             password: "$2a$10$NgKw9sCbuUEa.6Dlj4xKF.4u8XRA9lfEkAfWhWfxYo9kvAcIp7EZy",
-            nickname: "lee",
             name: "lee",
+            nickname: "lee",
             gender: "남자",
-            type: "일반"
+            genres: []
         )
     }
 }

--- a/CineHive/CineHive/Services/UserService.swift
+++ b/CineHive/CineHive/Services/UserService.swift
@@ -20,13 +20,13 @@ final class UserService {
     }
     
     /// 닉네임 중복 확인
-    func fetchUserNickname(nickname: String) async throws -> Bool {
+    func fetchUserNickname(nickname: String) async throws -> AvailabilityResponse {
         let endpoint = EndPoint.Auth.checkNickname(nickname)
         return try await NetworkManager.shared.fetch(endpoint: endpoint)
     }
     
     /// 이메일 중복 확인
-    func fetchUserEmail(email: String) async throws -> Bool {
+    func fetchUserEmail(email: String) async throws -> AvailabilityResponse {
         let endpoint = EndPoint.Auth.checkEmail(email)
         return try await NetworkManager.shared.fetch(endpoint: endpoint)
     }

--- a/CineHive/CineHive/Services/UserService.swift
+++ b/CineHive/CineHive/Services/UserService.swift
@@ -14,7 +14,7 @@ final class UserService {
     // MARK: - 인증 없는 요청 (로그인 전)
 
     /// 회원가입 요청
-    func registerUser(user: User) async throws -> SignUpResponse {
+    func registerUser(user: SignUpRequest) async throws -> SignUpResponse {
         let endpoint = EndPoint.Auth.register
         return try await NetworkManager.shared.post(endpoint: endpoint, body: user)
     }


### PR DESCRIPTION
## 작업한 내용
### 포커스 및 입력 UX 개선
- FocusState 기반으로 필드 포커스 제어 및 제출 이벤트 처리 로직 도입
- 포커스 상태에 따라 테두리 강조 효과 적용
- FocusState 로직 중앙 집중화 및 충돌 해결

### 회원가입 검증 로직 개선
- 이메일/닉네임 중복확인 엔드포인트 수정 및 응답 구조에 맞게 검사 로직 재작성
- 중복확인 방식 → 버튼 클릭 기반으로 변경
- 이메일 형식 검증 메시지 개선
- 비밀번호 확인란 추가 및 유효성 검사/결과 메시지 UI 반영
- 이메일, 닉네임, 이름 입력 글자 수 제한

### 모델/응답 구조 정비
- User 모델 서버 응답 구조에 맞게 수정
- gender 값 서버 포맷에 맞게 변환
- 회원가입 및 에러 응답 모델 구조 정비
- User 기본 생성 로직 및 관련 응답 구조 정리

### UI/기능 추가
- 성별 선택 해제 기능 추가
- 회원가입 화면 스크롤바 숨김 처리로 UI 단순화


## PR Point
### 입력/포커스 개선
- FocusState를 활용한 포커스 제어와 테두리 강조가 자연스럽게 동작하는지
- 포커스 충돌 해결 로직이 중복 없이 정리되었는지
### 검증 로직 및 서버 연동
- 이메일/닉네임 중복확인 API 호출 로직이 서버 응답 구조와 일치하는지
- 버튼 클릭 기반 중복확인 UX가 동작하는지
### 입력 제한 처리
- 이메일, 닉네임, 이름 입력 제한이 정상적으로 잘리는지

### 추후 작업할 내용 (미완성 부분)
<!-- 이슈 번호와 함께 향후 작업 예정인 내용을 작성해주세요 -->
<!-- 연결된 이슈가 있다면 작성해주세요 (예: #123) -->
<!-- 체크리스트 작성 (예: - [ ]) -->
X

## 스크린샷
<!-- UI 변경이 있는 경우 변경 전/후 스크린샷을 첨부해주세요 -->
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/c3943df4-2866-450c-b872-a54015b39086" width="200"/><br>
      <p>버튼 클릭 기반 중복확인</p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/460c513d-a075-48a9-8da9-d44014c349b9" width="200"><br>
      <p>비밀번호 유효성 검사 메시지</p>
    </td>
  </tr>
</table> 
