### PR TITLE
[Feature/migrate-to-supabase]: Supabase 연동 및 회원가입 로직 마이그레이션

### DIFF
--- a/CineHive/CineHive.xcodeproj/project.pbxproj
+++ b/CineHive/CineHive.xcodeproj/project.pbxproj
@@ -379,7 +379,8 @@
 		};
 		9BF396022D61F2A000044A64 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 48637B3AC248900F733A0508 /* Pods-CineHive.debug.xcconfig */;
+			baseConfigurationReferenceAnchor = 9BF395F52D61F29E00044A64 /* CineHive */;
+			baseConfigurationReferenceRelativePath = Config/Config.Debug.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -414,7 +415,8 @@
 		};
 		9BF396032D61F2A000044A64 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B3C0C1512991CDACD0534E14 /* Pods-CineHive.release.xcconfig */;
+			baseConfigurationReferenceAnchor = 9BF395F52D61F29E00044A64 /* CineHive */;
+			baseConfigurationReferenceRelativePath = Config/Config.Release.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/CineHive/CineHive.xcodeproj/project.pbxproj
+++ b/CineHive/CineHive.xcodeproj/project.pbxproj
@@ -8,6 +8,28 @@
 
 /* Begin PBXBuildFile section */
 		42382D740482D21FDD22E98C /* Pods_CineHive.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 737D24D6E2B542A5B5287265 /* Pods_CineHive.framework */; };
+		8CBD6C9E2E73F61500FA70B6 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = 8CBD6C9D2E73F61500FA70B6 /* Supabase */; };
+		8CE8BF8C2E72BC5100582C08 /* Auth in Frameworks */ = {isa = PBXBuildFile; productRef = 8CE8BF8B2E72BC5100582C08 /* Auth */; };
+		8CE8BF8E2E72BC5100582C08 /* PostgREST in Frameworks */ = {isa = PBXBuildFile; productRef = 8CE8BF8D2E72BC5100582C08 /* PostgREST */; };
+		8CE8BF902E72BC5100582C08 /* Storage in Frameworks */ = {isa = PBXBuildFile; productRef = 8CE8BF8F2E72BC5100582C08 /* Storage */; };
+		8CE8BF942E72BEF900582C08 /* Auth in Frameworks */ = {isa = PBXBuildFile; productRef = 8CE8BF932E72BEF900582C08 /* Auth */; };
+		8CE8BF962E72BEF900582C08 /* PostgREST in Frameworks */ = {isa = PBXBuildFile; productRef = 8CE8BF952E72BEF900582C08 /* PostgREST */; };
+		8CE8BF982E72BEF900582C08 /* Storage in Frameworks */ = {isa = PBXBuildFile; productRef = 8CE8BF972E72BEF900582C08 /* Storage */; };
+		8CE8BFC62E72CC5D00582C08 /* Auth in Frameworks */ = {isa = PBXBuildFile; productRef = 8CE8BFC52E72CC5D00582C08 /* Auth */; };
+		8CE8BFC82E72CC5D00582C08 /* Functions in Frameworks */ = {isa = PBXBuildFile; productRef = 8CE8BFC72E72CC5D00582C08 /* Functions */; };
+		8CE8BFCA2E72CC5D00582C08 /* PostgREST in Frameworks */ = {isa = PBXBuildFile; productRef = 8CE8BFC92E72CC5D00582C08 /* PostgREST */; };
+		8CE8BFCC2E72CC5D00582C08 /* Realtime in Frameworks */ = {isa = PBXBuildFile; productRef = 8CE8BFCB2E72CC5D00582C08 /* Realtime */; };
+		8CE8BFCE2E72CC5D00582C08 /* Storage in Frameworks */ = {isa = PBXBuildFile; productRef = 8CE8BFCD2E72CC5D00582C08 /* Storage */; };
+		8CE8C2A02E73F22200582C08 /* Auth in Frameworks */ = {isa = PBXBuildFile; productRef = 8CE8C29F2E73F22200582C08 /* Auth */; };
+		8CE8C2A22E73F22200582C08 /* Functions in Frameworks */ = {isa = PBXBuildFile; productRef = 8CE8C2A12E73F22200582C08 /* Functions */; };
+		8CE8C2A42E73F22200582C08 /* PostgREST in Frameworks */ = {isa = PBXBuildFile; productRef = 8CE8C2A32E73F22200582C08 /* PostgREST */; };
+		8CE8C2A62E73F22200582C08 /* Realtime in Frameworks */ = {isa = PBXBuildFile; productRef = 8CE8C2A52E73F22200582C08 /* Realtime */; };
+		8CE8C2A82E73F22200582C08 /* Storage in Frameworks */ = {isa = PBXBuildFile; productRef = 8CE8C2A72E73F22200582C08 /* Storage */; };
+		8CE8C2AB2E73F26300582C08 /* Auth in Frameworks */ = {isa = PBXBuildFile; productRef = 8CE8C2AA2E73F26300582C08 /* Auth */; };
+		8CE8C2AD2E73F26300582C08 /* PostgREST in Frameworks */ = {isa = PBXBuildFile; productRef = 8CE8C2AC2E73F26300582C08 /* PostgREST */; };
+		8CE8C4182E73F40400582C08 /* Auth in Frameworks */ = {isa = PBXBuildFile; productRef = 8CE8C4172E73F40400582C08 /* Auth */; };
+		8CE8C41A2E73F40400582C08 /* PostgREST in Frameworks */ = {isa = PBXBuildFile; productRef = 8CE8C4192E73F40400582C08 /* PostgREST */; };
+		8CE8C41C2E73F40400582C08 /* Storage in Frameworks */ = {isa = PBXBuildFile; productRef = 8CE8C41B2E73F40400582C08 /* Storage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -43,7 +65,29 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8CE8BFCE2E72CC5D00582C08 /* Storage in Frameworks */,
+				8CE8BF962E72BEF900582C08 /* PostgREST in Frameworks */,
+				8CE8C41C2E73F40400582C08 /* Storage in Frameworks */,
+				8CBD6C9E2E73F61500FA70B6 /* Supabase in Frameworks */,
+				8CE8C2AD2E73F26300582C08 /* PostgREST in Frameworks */,
+				8CE8C2AB2E73F26300582C08 /* Auth in Frameworks */,
+				8CE8BF902E72BC5100582C08 /* Storage in Frameworks */,
+				8CE8BF982E72BEF900582C08 /* Storage in Frameworks */,
+				8CE8C2A22E73F22200582C08 /* Functions in Frameworks */,
+				8CE8BFC82E72CC5D00582C08 /* Functions in Frameworks */,
+				8CE8C2A82E73F22200582C08 /* Storage in Frameworks */,
+				8CE8C41A2E73F40400582C08 /* PostgREST in Frameworks */,
+				8CE8BFCA2E72CC5D00582C08 /* PostgREST in Frameworks */,
+				8CE8BF8E2E72BC5100582C08 /* PostgREST in Frameworks */,
+				8CE8C2A02E73F22200582C08 /* Auth in Frameworks */,
+				8CE8C2A42E73F22200582C08 /* PostgREST in Frameworks */,
+				8CE8BF8C2E72BC5100582C08 /* Auth in Frameworks */,
+				8CE8C2A62E73F22200582C08 /* Realtime in Frameworks */,
+				8CE8BF942E72BEF900582C08 /* Auth in Frameworks */,
+				8CE8BFC62E72CC5D00582C08 /* Auth in Frameworks */,
 				42382D740482D21FDD22E98C /* Pods_CineHive.framework in Frameworks */,
+				8CE8C4182E73F40400582C08 /* Auth in Frameworks */,
+				8CE8BFCC2E72CC5D00582C08 /* Realtime in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -134,6 +178,9 @@
 			);
 			mainGroup = 9BF395EA2D61F29E00044A64;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				8CE8C4162E73F40400582C08 /* XCRemoteSwiftPackageReference "supabase-swift" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 9BF395F42D61F29E00044A64 /* Products */;
 			projectDirPath = "";
@@ -356,6 +403,9 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "kr.co.Cine-Hive.CineHive";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -388,6 +438,9 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "kr.co.Cine-Hive.CineHive";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -416,6 +469,133 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		8CE8BF8A2E72BC5100582C08 /* XCRemoteSwiftPackageReference "supabase-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/supabase-community/supabase-swift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.5.1;
+			};
+		};
+		8CE8C2A92E73F26300582C08 /* XCRemoteSwiftPackageReference "supabase-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/supabase/supabase-swift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.5.1;
+			};
+		};
+		8CE8C4162E73F40400582C08 /* XCRemoteSwiftPackageReference "supabase-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/supabase/supabase-swift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.5.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		8CBD6C9D2E73F61500FA70B6 /* Supabase */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8CE8C4162E73F40400582C08 /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = Supabase;
+		};
+		8CE8BF8B2E72BC5100582C08 /* Auth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8CE8BF8A2E72BC5100582C08 /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = Auth;
+		};
+		8CE8BF8D2E72BC5100582C08 /* PostgREST */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8CE8BF8A2E72BC5100582C08 /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = PostgREST;
+		};
+		8CE8BF8F2E72BC5100582C08 /* Storage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8CE8BF8A2E72BC5100582C08 /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = Storage;
+		};
+		8CE8BF932E72BEF900582C08 /* Auth */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Auth;
+		};
+		8CE8BF952E72BEF900582C08 /* PostgREST */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = PostgREST;
+		};
+		8CE8BF972E72BEF900582C08 /* Storage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Storage;
+		};
+		8CE8BFC52E72CC5D00582C08 /* Auth */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Auth;
+		};
+		8CE8BFC72E72CC5D00582C08 /* Functions */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Functions;
+		};
+		8CE8BFC92E72CC5D00582C08 /* PostgREST */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = PostgREST;
+		};
+		8CE8BFCB2E72CC5D00582C08 /* Realtime */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Realtime;
+		};
+		8CE8BFCD2E72CC5D00582C08 /* Storage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Storage;
+		};
+		8CE8C29F2E73F22200582C08 /* Auth */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Auth;
+		};
+		8CE8C2A12E73F22200582C08 /* Functions */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Functions;
+		};
+		8CE8C2A32E73F22200582C08 /* PostgREST */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = PostgREST;
+		};
+		8CE8C2A52E73F22200582C08 /* Realtime */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Realtime;
+		};
+		8CE8C2A72E73F22200582C08 /* Storage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Storage;
+		};
+		8CE8C2AA2E73F26300582C08 /* Auth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8CE8C2A92E73F26300582C08 /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = Auth;
+		};
+		8CE8C2AC2E73F26300582C08 /* PostgREST */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8CE8C2A92E73F26300582C08 /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = PostgREST;
+		};
+		8CE8C4172E73F40400582C08 /* Auth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8CE8C4162E73F40400582C08 /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = Auth;
+		};
+		8CE8C4192E73F40400582C08 /* PostgREST */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8CE8C4162E73F40400582C08 /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = PostgREST;
+		};
+		8CE8C41B2E73F40400582C08 /* Storage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8CE8C4162E73F40400582C08 /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = Storage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 9BF395EB2D61F29E00044A64 /* Project object */;
 }

--- a/CineHive/CineHive.xcodeproj/xcshareddata/xcschemes/CineHive.xcscheme
+++ b/CineHive/CineHive.xcodeproj/xcshareddata/xcschemes/CineHive.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9BF395F22D61F29E00044A64"
+               BuildableName = "CineHive.app"
+               BlueprintName = "CineHive"
+               ReferencedContainer = "container:CineHive.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9BF395F22D61F29E00044A64"
+            BuildableName = "CineHive.app"
+            BlueprintName = "CineHive"
+            ReferencedContainer = "container:CineHive.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9BF395F22D61F29E00044A64"
+            BuildableName = "CineHive.app"
+            BlueprintName = "CineHive"
+            ReferencedContainer = "container:CineHive.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/CineHive/CineHive/Core/Models/Board.swift
+++ b/CineHive/CineHive/Core/Models/Board.swift
@@ -11,7 +11,7 @@ struct Board: Identifiable, Codable {
     let id: Int
     let title: String
     let content: String
-    let user: User?
+    let user: Profile?
     let createdAt: String
     let viewCount: Int
     var likeCount: Int
@@ -50,13 +50,14 @@ struct Board: Identifiable, Codable {
         self.commentCount = try container.decodeIfPresent(Int.self, forKey: .commentCount) ?? 0
 
         // user가 있는 경우와 없는 경우 모두 대응
-        if let user = try? container.decode(User.self, forKey: .user) {
+        if let user = try? container.decode(Profile.self, forKey: .user) {
             self.user = user
         } else {
             let nickname = try container.decodeIfPresent(String.self, forKey: .nickname) ?? "알 수 없음"
-            self.user = User(
+            self.user = Profile(
+                id: UUID(),
                 email: "unknown@email.com",
-                password: "",
+                //password: "",
                 name: nil,
                 nickname: nickname,
                 gender: nil,

--- a/CineHive/CineHive/Core/Models/Comment.swift
+++ b/CineHive/CineHive/Core/Models/Comment.swift
@@ -10,7 +10,7 @@ import Foundation
 struct Comment: Identifiable, Codable {
     let id: Int
     let content: String
-    let user: User
+    let user: Profile
     let createdAt: String
     var author: String { user.nickname }
     var email: String { user.email }

--- a/CineHive/CineHive/Core/Models/DTO/Auth/AuthSignUpRequest.swift
+++ b/CineHive/CineHive/Core/Models/DTO/Auth/AuthSignUpRequest.swift
@@ -1,0 +1,14 @@
+//
+//  SignUpRequest.swift
+//  CineHive
+//
+//  Created by 존진 on 9/17/25.
+//
+
+import Foundation
+
+// 소셜 회원 가입 요청 DTO
+struct AuthSignUpRequest: Encodable {
+    let email: String
+    let password: String
+}

--- a/CineHive/CineHive/Core/Models/Domain/Profile.swift
+++ b/CineHive/CineHive/Core/Models/Domain/Profile.swift
@@ -6,28 +6,36 @@
 //
 
 import Foundation
+import Supabase
 
-struct User: Codable {
+// MARK: - 도메인 모델: 앱 내부 표준
+struct Profile: Codable {
+    let id: UUID
     let email: String
-    let password: String
     let name: String?
     let nickname: String
-    let gender: String?
+    let gender: Gender?
     let genres: [String]?
     
     enum CodingKeys: String, CodingKey {
+        case id
         case email
-        case password
         case name
         case nickname
         case gender
         case genres
     }
     
+    enum Gender: String, Codable {
+        case male = "MALE"
+        case female = "FEMALE"
+        case other = "OTHER"
+    }
+    
     // 기본 생성자
-    init(email: String, password: String, name: String?, nickname: String, gender: String?, genres: [String]?) {
+    init(id:UUID, email: String, name: String?, nickname: String, gender: Gender?, genres: [String]?) {
+        self.id = id
         self.email = email
-        self.password = password
         self.name = name
         self.nickname = nickname
         self.gender = gender
@@ -88,16 +96,6 @@ struct UserData: Codable {
         case gender
         case genres
     }
-}
-
-struct SignUpRequest: Codable {
-    let email: String
-    let password: String
-    let confirmPassword: String
-    let name: String?
-    let nickname: String
-    let gender: String?
-    let genres: [String]
 }
 
 struct SignUpResponse: Codable {

--- a/CineHive/CineHive/Core/Network/SupabaseConfig.swift
+++ b/CineHive/CineHive/Core/Network/SupabaseConfig.swift
@@ -1,0 +1,25 @@
+//
+//  SupabaseConfig.swift
+//  CineHive
+//
+//  Created by 존진 on 9/11/25.
+//
+
+import Foundation
+import Supabase
+
+class SupabaseConfig {
+    static let shared = SupabaseConfig()  // 싱글톤 인스턴스
+
+    let client: SupabaseClient
+
+    private init() {
+        guard let supabaseURL = Bundle.main.object(forInfoDictionaryKey: "SUPABASE_URL") as? String,
+              let supabaseKey = Bundle.main.object(forInfoDictionaryKey: "SUPABASE_ANON_KEY") as? String else {
+            fatalError("Supabase credentials not found")
+        }
+
+        self.client = SupabaseClient(supabaseURL: URL(string: supabaseURL)!,
+                                     supabaseKey: supabaseKey)
+    }
+}

--- a/CineHive/CineHive/Core/State/UserState.swift
+++ b/CineHive/CineHive/Core/State/UserState.swift
@@ -186,7 +186,7 @@ final class UserState {
     
     /// 회원가입 처리
     @MainActor
-    func signUp(user: SignUpRequest) async -> Bool {
+    func signUp(user: AuthSignUpRequest) async -> Bool {
         isLoading = true
         errorMessage = nil
         

--- a/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+import Supabase
+import Auth
+import PostgREST
 
 enum PasswordValidationError: String {
     case space = "공백 문자는 사용할 수 없습니다."
@@ -99,13 +102,24 @@ class SignUpViewModel {
     // 닉네임 중복 검사
     @MainActor
     func checkValidateNickname() async {
-        let (_, isAvailable) = await UserState.shared.checkNickname(nickname)
-        
-        if isAvailable {
-            self.nicknameCheckMessage = "사용 가능한 닉네임입니다."
-            self.nicknameAvailable = true
-        }else {
-            self.emailCheckMessage = "이미 사용 중인 닉네임입니다."
+        do {
+            let client = SupabaseConfig.shared.client
+            let response = try await client
+                .from("profiles")
+                .select("nickname", head: true, count: .exact)
+                .eq("nickname", value: nickname)
+                .limit(1)
+                .execute()
+            let available = (response.count ?? 0) == 0
+            if available {
+                self.nicknameCheckMessage = "사용 가능한 닉네임입니다."
+                self.nicknameAvailable = true
+            } else {
+                self.nicknameCheckMessage = "이미 사용 중인 닉네임입니다."
+                self.nicknameAvailable = false
+            }
+        } catch {
+            self.nicknameCheckMessage = "닉네임 확인 실패: \(error.localizedDescription)"
             self.nicknameAvailable = false
         }
     }
@@ -114,27 +128,60 @@ class SignUpViewModel {
     @MainActor
     func signUp() async {
         isSigningUp = true
+        defer { isSigningUp = false }
         generalErrorMessage = nil
         let convertedGender = (gender == "남자") ? "MALE" : "FEMALE"
         
-        let newUser = SignUpRequest(
-            email: email,
-            password: password,
-            confirmPassword: confirmPassword,
-            name: name,
-            nickname: nickname,
-            gender: convertedGender,
-            genres: genres
-        )
-        
-        let success = await UserState.shared.signUp(user: newUser)
-        
-        isSigningUp = false
-        
-        if success {
-            isSignUpSuccess = true
-        } else {
-            generalErrorMessage = UserState.shared.errorMessage ?? "회원가입에 실패했습니다."
+        do {
+            let client = SupabaseConfig.shared.client
+            
+            // 2) Supabase Auth 회원가입 (이메일 중복 시 여기서 에러 발생)
+            let authResponse = try await client.auth.signUp(
+                email: email,
+                password: password,
+                data: [
+                    "nickname": .string(nickname),
+                    "name": .string(name),
+                    "gender": .string(convertedGender)
+                ]
+            )
+            
+            // 2) 세션이 있으면 즉시 로그인 상태이므로 DB write 수행
+            if let session = authResponse.session {
+                let userId = session.user.id.uuidString
+                
+                try await client
+                    .from("profiles")
+                    .upsert([
+                        "id": userId,
+                        "email": email,
+                        "nickname": nickname,
+                        "name": name,
+                        "gender": convertedGender,
+                        "type": "user"
+                    ], onConflict: "id")
+                    .execute()
+                
+                isSignUpSuccess = true
+            }
+            // 3) 세션은 없고 user만 있으면(이메일 인증 필요) → 가입 성공 처리만
+            else if authResponse.user != nil {
+                isSignUpSuccess = true
+                // 프로필 생성은 이메일 인증 후 로그인 시점에 진행
+            } else {
+                throw NSError(domain: "SignUp", code: -2, userInfo: [NSLocalizedDescriptionKey: "회원가입 응답에 세션/사용자 정보가 없습니다."])
+            }
+        } catch {
+            let msg = error.localizedDescription.lowercased()
+            if msg.contains("already registered") || msg.contains("already exists") || msg.contains("user exists") {
+                generalErrorMessage = "이미 사용 중인 이메일입니다."
+            } else if msg.contains("password") {
+                generalErrorMessage = "비밀번호 요건을 확인해 주세요."
+            } else {
+                generalErrorMessage = "회원가입 실패: \(error.localizedDescription)"
+            }
+            isSignUpSuccess = false
+            
         }
     }
 }

--- a/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
@@ -157,8 +157,7 @@ class SignUpViewModel {
                         "email": email,
                         "nickname": nickname,
                         "name": name,
-                        "gender": convertedGender,
-                        "type": "user"
+                        "gender": convertedGender
                     ], onConflict: "id")
                     .execute()
                 

--- a/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
@@ -99,28 +99,42 @@ class SignUpViewModel {
         }
     }
     
-    // 닉네임 중복 검사
+    // 닉네임 중복 검사 (RPC 사용)
     @MainActor
     func checkValidateNickname() async {
+        // 공백이나 줄바꿈 문자 제거
+        let trimmed = nickname.trimmingCharacters(in: .whitespacesAndNewlines)
+        
         do {
             let client = SupabaseConfig.shared.client
+            // 파라미터 타입을 명시적으로 AnyJSON으로 지정
+            let params: [String: AnyJSON] = [
+                "p_nickname": .string(trimmed)
+            ]
             let response = try await client
-                .from("profiles")
-                .select("nickname", head: true, count: .exact)
-                .eq("nickname", value: nickname)
-                .limit(1)
+                .rpc("check_nickname_available", params: params)
                 .execute()
-            let available = (response.count ?? 0) == 0
-            if available {
-                self.nicknameCheckMessage = "사용 가능한 닉네임입니다."
-                self.nicknameAvailable = true
-            } else {
-                self.nicknameCheckMessage = "이미 사용 중인 닉네임입니다."
+            
+            let data = response.data
+            guard !data.isEmpty else {
                 self.nicknameAvailable = false
+                self.nicknameCheckMessage = "닉네임 확인 실패: 빈 응답"
+                return
             }
-        } catch {
-            self.nicknameCheckMessage = "닉네임 확인 실패: \(error.localizedDescription)"
+            
+            // 단일 Bool (true/false)
+            if let available = try? JSONDecoder().decode(Bool.self, from: data) {
+                self.nicknameAvailable = available
+                self.nicknameCheckMessage = available ? "사용 가능한 닉네임입니다." : "이미 사용 중인 닉네임입니다."
+                return
+            }
+            
+            // 파싱 실패
             self.nicknameAvailable = false
+            self.nicknameCheckMessage = "닉네임 확인 실패: 응답 형식 오류"
+        } catch {
+            self.nicknameAvailable = false
+            self.nicknameCheckMessage = "닉네임 확인 실패: \(error.localizedDescription)"
         }
     }
     
@@ -135,35 +149,24 @@ class SignUpViewModel {
         do {
             let client = SupabaseConfig.shared.client
             
-            // 2) Supabase Auth 회원가입 (이메일 중복 시 여기서 에러 발생)
+            let metadata: [String: AnyJSON] = [
+                "nickname": .string(nickname),
+                "name": .string(name),
+                "gender": .string(convertedGender)
+            ]
+            
+            // Supabase Auth 회원가입
             let authResponse = try await client.auth.signUp(
                 email: email,
                 password: password,
-                data: [
-                    "nickname": .string(nickname),
-                    "name": .string(name),
-                    "gender": .string(convertedGender)
-                ]
+                data: metadata
             )
             
-            // 2) 세션이 있으면 즉시 로그인 상태이므로 DB write 수행
+            // 세션 O -> Supabase trigger에서 프로필 생성 처리
             if let session = authResponse.session {
-                let userId = session.user.id.uuidString
-                
-                try await client
-                    .from("profiles")
-                    .upsert([
-                        "id": userId,
-                        "email": email,
-                        "nickname": nickname,
-                        "name": name,
-                        "gender": convertedGender
-                    ], onConflict: "id")
-                    .execute()
-                
-                isSignUpSuccess = true
+                // 프로필 생성은 Supabase 트리거에서 처리
             }
-            // 3) 세션은 없고 user만 있으면(이메일 인증 필요) → 가입 성공 처리만
+            // 세션 X -> 이메일 인증 필요
             else if authResponse.user != nil {
                 isSignUpSuccess = true
                 // 프로필 생성은 이메일 인증 후 로그인 시점에 진행

--- a/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
@@ -41,9 +41,11 @@ class SignUpViewModel {
     
     // 필수 필드 채워져 있는지 검사 및 중복검사 결과에 따른 회원가입 버튼 활성화
     func isValid() -> Bool {
+        let validEmail = isValidEmail(email)
+        let (validPassword, _) = isValidPassword(password)
+        let confirmPasswordMatch = !confirmPassword.isEmpty && password == confirmPassword
         return !email.isEmpty && !password.isEmpty && !confirmPassword.isEmpty && !nickname.isEmpty &&
-        isValidEmail(email) && isValidPassword(password).0 &&
-               nicknameAvailable && emailAvailable
+        validEmail && validPassword && confirmPasswordMatch && nicknameAvailable
     }
     
     // 비밀번호 유효성 검사: 영문 대소문자, 숫자, 특수문자 포함 8~20자, 공백 불가
@@ -80,29 +82,17 @@ class SignUpViewModel {
         return isValid
     }
     
-    // 이메일 중복 검사
-    @MainActor
-    func checkValidateEmail() async {
-        let (_, isAvailable) = await UserState.shared.checkEmail(email)
-        
-        if isAvailable {
-            self.emailCheckMessage = "사용 가능한 이메일입니다."
-            self.emailAvailable = true
-        } else {
-            self.emailCheckMessage = "이미 사용 중인 이메일입니다."
-            self.emailAvailable = false
-        }
-    }
-
-    // 이메일 형식 검사 후 중복 검사
+    // 이메일 형식 검사
     @MainActor
     func checkEmailWithFormatValidation() async {
-        if isValidEmail(email) {
-            emailFormatInvalidMessage = nil
-            await checkValidateEmail()
+        if !isValidEmail(email) {
+            self.emailFormatInvalidMessage = nil
+            self.emailCheckMessage = "이메일 형식이 유효하지 않습니다."
+            self.emailAvailable = false
         } else {
-            emailCheckMessage = nil
-            emailFormatInvalidMessage = "이메일의 형식이 맞지 않습니다."
+            self.emailFormatInvalidMessage = nil
+            self.emailCheckMessage = ""
+            self.emailAvailable = true
         }
     }
     

--- a/CineHive/CineHive/Resources/Dummy/User+Dummy.swift
+++ b/CineHive/CineHive/Resources/Dummy/User+Dummy.swift
@@ -7,14 +7,14 @@
 
 import Foundation
 
-extension User {
-    static var dummy1: User {
-        User(
+extension Profile {
+    static var dummy1: Profile {
+        Profile(
+            id: UUID(),
             email: "unib335@naver.com",
-            password: "$2a$10$NgKw9sCbuUEa.6Dlj4xKF.4u8XRA9lfEkAfWhWfxYo9kvAcIp7EZy",
             name: "lee",
             nickname: "lee",
-            gender: "남자",
+            gender: Profile.Gender.male,
             genres: []
         )
     }

--- a/CineHive/CineHive/Services/UserService.swift
+++ b/CineHive/CineHive/Services/UserService.swift
@@ -14,7 +14,7 @@ final class UserService {
     // MARK: - 인증 없는 요청 (로그인 전)
 
     /// 회원가입 요청
-    func registerUser(user: SignUpRequest) async throws -> SignUpResponse {
+    func registerUser(user: AuthSignUpRequest) async throws -> SignUpResponse {
         let endpoint = EndPoint.Auth.register
         return try await NetworkManager.shared.post(endpoint: endpoint, body: user)
     }


### PR DESCRIPTION
## 작업한 내용
- Supabase SDK 설치 및 환경설정 (xcconfig, Info.plist)
- SupabaseConfig.swift 파일 추가 (URL, Anon Key 관리)
- 회원가입 로직을 Supabase Auth.signUp 기반으로 변경
- 닉네임 중복 확인 → Supabase RPC(check_nickname_available)로 구현
- Domain 모델 User → Profile로 교체
- 불필요한 DTO 및 코드(SignUpRequest, ProfileInsert 등) 제거

## PR Point
- 회원가입 로직이 Supabase 기반으로 정상 동작하는지 확인 필요
- 닉네임 중복 확인 RPC 호출이 안정적으로 파싱되는지 확인 필요
- 환경설정(Config.Debug.xcconfig, Info.plist) 구조가 팀 내 협업 시 문제 없는지 검토 필요

### 추후 작업할 내용 (미완성 부분)
<!-- 이슈 번호와 함께 향후 작업 예정인 내용을 작성해주세요 -->
<!-- 연결된 이슈가 있다면 작성해주세요 (예: #123) -->
<!-- 체크리스트 작성 (예: - [ ]) -->
- 로그인 및 소셜 로그인 로직 Supabase로 마이그레이션
- 이메일 인증 UX 개선 및 처리 방식

## 스크린샷
<!-- UI 변경이 있는 경우 변경 전/후 스크린샷을 첨부해주세요 -->
X
