### PR TITLE
[Feature/signup-UI-v2]: 회원가입 UI 개선

### DIFF
--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -102,8 +102,6 @@ struct SignUpView: View {
                 .disabled(!viewModel.isValid() || viewModel.isSigningUp || viewModel.password != viewModel.confirmPassword)
                 Spacer()
             }
-            .padding(.bottom, 20)
-            
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button {
@@ -118,6 +116,7 @@ struct SignUpView: View {
                         .font(.system(size: 20, weight: .medium))
                 }
             }
+            .navigationBarTitleDisplayMode(.inline)
             .navigationBarBackButtonHidden(false)
             .safeAreaInset(edge: .top) {
                 Divider()

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -45,29 +45,31 @@ struct SignUpView: View {
     var body: some View {
             VStack {
                 VStack(spacing: 0) {
-                    HStack {
-                        Button(action: {
-                            switch step {
-                            case .email:
-                                dismiss() // 첫 단계에서는 실제 뒤로가기(닫기)
-                            case .password:
-                                step = .email
-                            case .confirmPassword:
-                                step = .password
-                            case .nickname:
-                                step = .confirmPassword
-                            }
-                        }) {
-                            Image(systemName: "chevron.left")
-                                .foregroundStyle(Color("FontColor"))
-                                .frame(width: 15, height: 24)
-                        }
-                        Spacer()
+                    ZStack {
+                        // Centered title always stays centered
                         Text("회원가입")
                             .font(.system(size: 20, weight: .medium))
-                        Spacer()
-                        Color.clear
-                            .frame(width: 24, height: 24)
+                            .frame(maxWidth: .infinity, alignment: .center)
+
+                        // Leading back button layered on top
+                        HStack {
+                            Button(action: {
+                                switch step {
+                                case .email:
+                                    dismiss() // 첫 단계에서는 실제 뒤로가기(닫기)
+                                case .password:
+                                    step = .email
+                                case .confirmPassword:
+                                    step = .password
+                                case .nickname:
+                                    step = .confirmPassword
+                                }
+                            }) {
+                                Image(systemName: "chevron.left")
+                                    .foregroundStyle(Color("FontColor"))
+                            }
+                            Spacer()
+                        }
                     }
                     .padding(.horizontal, 16)
                     .frame(height: 44)
@@ -142,6 +144,7 @@ struct SignUpView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 12))
                 .disabled(!nextEnabled)
                 .padding(.horizontal, 16)
+                .padding(.bottom, 5)
             }
             .onAppear { focusedField = .email }
             .onChange(of: step) { newStep, _ in

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -82,15 +82,9 @@ struct SignUpView: View {
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 25)
-                    .padding(.top, 15)
+                    .padding(.top, 10)
                 case .confirmPassword:
                     PasswordFieldView(title: "비밀번호를 한 번 더 입력해 주세요.", text: $viewModel.confirmPassword, showPassword: $viewModel.showPassword, focus: $focusedField, field: .confirmPassword)
-                    if focusedField != .confirmPassword, !viewModel.confirmPassword.isEmpty && viewModel.password != viewModel.confirmPassword {
-                        Text("비밀번호가 일치하지 않습니다.")
-                            .font(.system(size: 14))
-                            .foregroundColor(.red)
-                            .frame(width: 325, alignment: .leading)
-                    }
                 case .nickname:
                     ValidatedInputField(
                         title: "닉네임을 입력해 주세요.",

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -14,49 +14,30 @@ enum SignUpFocusField: Hashable {
     case nickname
 }
 
+enum SignUpStep: Int, CaseIterable { case email, password, confirmPassword, nickname }
+
 struct SignUpView: View {
     @State private var viewModel = SignUpViewModel()
     @Environment(\.dismiss) private var dismiss
     @FocusState private var focusedField: SignUpFocusField?
-    // 멀티 스텝 진행 상태
-    private enum Step: Int, CaseIterable { case email, password, confirmPassword, nickname }
-    @State private var step: Step = .email
+    @State private var step: SignUpStep = .email
     
     // 회원가입 완료 시 상위 화면으로 성공 콜백 전달
     var onSignUpSuccess: (() -> Void)? = nil
-    
-    // 다음 버튼 활성화 상태
-    private var nextEnabled: Bool { isNextEnabled() }
-    
-    // 다음 버튼 활성화 로직
-    private func isNextEnabled() -> Bool {
-        switch step {
-        case .email:
-            return !viewModel.email.isEmpty && viewModel.isValidEmail(viewModel.email)
-        case .password:
-            return !viewModel.password.isEmpty && viewModel.passwordErrorMessage == nil
-        case .confirmPassword:
-            return !viewModel.confirmPassword.isEmpty && viewModel.password == viewModel.confirmPassword
-        case .nickname:
-            return !viewModel.nickname.isEmpty
-        }
-    }
     
     var body: some View {
             VStack {
                 VStack(spacing: 0) {
                     ZStack {
-                        // Centered title always stays centered
                         Text("회원가입")
-                            .font(.system(size: 20, weight: .medium))
+                            .font(.system(size: 18, weight: .medium))
                             .frame(maxWidth: .infinity, alignment: .center)
 
-                        // Leading back button layered on top
                         HStack {
                             Button(action: {
                                 switch step {
                                 case .email:
-                                    dismiss() // 첫 단계에서는 실제 뒤로가기(닫기)
+                                    dismiss()
                                 case .password:
                                     step = .email
                                 case .confirmPassword:
@@ -92,7 +73,9 @@ struct SignUpView: View {
                         Text(errorMessage)
                             .font(.system(size: 14))
                             .foregroundColor(.red)
-                            .frame(width: 325, alignment: .leading)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.leading, 30)
+                            .padding(.top, 10)
                     }
                 case .confirmPassword:
                     PasswordFieldView(title: "비밀번호를 한 번 더 입력해 주세요.", text: $viewModel.confirmPassword, showPassword: $viewModel.showPassword, focus: $focusedField, field: .confirmPassword)
@@ -140,9 +123,9 @@ struct SignUpView: View {
                         .frame(minHeight: 48)
                 })
                 .foregroundStyle(.white)
-                .background(nextEnabled ? Color("LoginBtnColor") : Color.gray)
+                .background(viewModel.isNextEnabled(step: step) ? Color("LoginBtnColor") : Color.gray)
                 .clipShape(RoundedRectangle(cornerRadius: 12))
-                .disabled(!nextEnabled)
+                .disabled(!viewModel.isNextEnabled(step: step))
                 .padding(.horizontal, 16)
                 .padding(.bottom, 5)
             }
@@ -217,7 +200,7 @@ struct PasswordFieldView: View {
                     self.showPassword.toggle()
                 }, label: {
                     Image(systemName: showPassword ? "eye" : "eye.slash")
-                        .padding(.trailing, 1)
+                        .padding(.trailing, 10)
                         .foregroundStyle(.gray)
                 })
             }

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -69,14 +69,20 @@ struct SignUpView: View {
                     )
                 case .password:
                     PasswordFieldView(title: "비밀번호를 입력해 주세요.", text: $viewModel.password, showPassword: $viewModel.showPassword, focus: $focusedField, field: .password)
-                    if let errorMessage = viewModel.passwordErrorMessage {
-                        Text(errorMessage)
-                            .font(.system(size: 14))
-                            .foregroundColor(Color("FontColor"))
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.leading, 30)
-                            .padding(.top, 10)
+                    VStack(alignment: .leading, spacing: 6) {
+                        ForEach(viewModel.passwordChecks, id: \.title) { check in
+                            HStack(spacing: 8) {
+                                Image(systemName: check.passed ? "checkmark.circle.fill" : "circle")
+                                    .foregroundColor(check.passed ? .green : .gray)
+                                Text(check.title)
+                                    .font(.system(size: 14))
+                                    .foregroundColor(check.passed ? .green : .gray)
+                            }
+                        }
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 25)
+                    .padding(.top, 15)
                 case .confirmPassword:
                     PasswordFieldView(title: "비밀번호를 한 번 더 입력해 주세요.", text: $viewModel.confirmPassword, showPassword: $viewModel.showPassword, focus: $focusedField, field: .confirmPassword)
                     if focusedField != .confirmPassword, !viewModel.confirmPassword.isEmpty && viewModel.password != viewModel.confirmPassword {

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -22,91 +22,88 @@ struct SignUpView: View {
     
     var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack {
-                    ValidatedInputField(
-                        title: "이메일",
-                        text: $viewModel.email,
-                        onCheckDuplicate: { await viewModel.checkEmailWithFormatValidation() },
-                        focus: $focusedField,
-                        field: .email
-                    )
-                    
-                    if let formatMessage = viewModel.emailFormatInvalidMessage {
-                        Text(formatMessage)
-                            .font(.system(size: 14))
-                            .foregroundColor(.red)
-                            .frame(width: 325, alignment: .leading)
-                    }
-                    
-                    if !viewModel.email.isEmpty, let emailCheck = viewModel.emailCheckMessage {
-                        Text(emailCheck)
-                            .font(.system(size: 14))
-                            .foregroundColor(emailCheck == "사용 가능한 이메일입니다." ? .green : .red)
-                            .frame(width: 330, alignment: .leading)
-                    }
-                    
-                    PasswordFieldView(title: "비밀번호", text: $viewModel.password, showPassword: $viewModel.showPassword, focus: $focusedField, field: .password)
-                    
-                    if focusedField != .password, let errorMessage = viewModel.passwordErrorMessage {
-                        Text(errorMessage)
-                            .font(.system(size: 14))
-                            .foregroundColor(.red)
-                            .frame(width: 325, alignment: .leading)
-                    }
-                    
-                    PasswordFieldView(title: "비밀번호 확인", text: $viewModel.confirmPassword, showPassword: $viewModel.showPassword, focus: $focusedField, field: .confirmPassword)
-                    
-                    if focusedField != .confirmPassword, !viewModel.confirmPassword.isEmpty && viewModel.password != viewModel.confirmPassword {
-                        Text("비밀번호가 일치하지 않습니다.")
-                            .font(.system(size: 14))
-                            .foregroundColor(.red)
-                            .frame(width: 325, alignment: .leading)
-                    }
-                    
-                    ValidatedInputField(
-                        title: "닉네임",
-                        text: $viewModel.nickname,
-                        onCheckDuplicate: { await viewModel.checkValidateNickname() },
-                        focus: $focusedField,
-                        field: .nickname
-                    )
-                    
-                    if let nicknameCheck = viewModel.nicknameCheckMessage {
-                        Text(nicknameCheck)
-                            .font(.system(size: 14))
-                            .foregroundColor(nicknameCheck == "사용 가능한 닉네임입니다." ? .green : .red)
-                            .frame(width: 325, alignment: .leading)
-                            .padding(.top, 1)
-                    }
-                    
-                    Button(action: {
-                        Task {
-                            await viewModel.signUp()
-                        }
-                    }, label: {
-                        HStack {
-                            if viewModel.isSigningUp {
-                                ProgressView()
-                                    .tint(.white)
-                                    .padding(.trailing, 8)
-                            }
-                            Text("회원가입")
-                        }
-                        .font(.system(size: 18, weight: .bold))
-                        .foregroundStyle(.white)
-                        .frame(width: 330, height: 50)
-                        .background(viewModel.isValid() ? Color("LoginBtnColor") : Color.gray)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
-                    })
-                    .padding(.top, 16)
-                    .disabled(!viewModel.isValid() || viewModel.isSigningUp || viewModel.password != viewModel.confirmPassword)
-                    Spacer()
+            VStack {
+                ValidatedInputField(
+                    title: "이메일",
+                    text: $viewModel.email,
+                    onCheckDuplicate: { await viewModel.checkEmailWithFormatValidation() },
+                    focus: $focusedField,
+                    field: .email
+                )
+                
+                if let formatMessage = viewModel.emailFormatInvalidMessage {
+                    Text(formatMessage)
+                        .font(.system(size: 14))
+                        .foregroundColor(.red)
+                        .frame(width: 325, alignment: .leading)
                 }
-                .padding(.bottom, 20)
+                
+                if !viewModel.email.isEmpty, let emailCheck = viewModel.emailCheckMessage {
+                    Text(emailCheck)
+                        .font(.system(size: 14))
+                        .foregroundColor(emailCheck == "사용 가능한 이메일입니다." ? .green : .red)
+                        .frame(width: 330, alignment: .leading)
+                }
+                
+                PasswordFieldView(title: "비밀번호", text: $viewModel.password, showPassword: $viewModel.showPassword, focus: $focusedField, field: .password)
+                
+                if focusedField != .password, let errorMessage = viewModel.passwordErrorMessage {
+                    Text(errorMessage)
+                        .font(.system(size: 14))
+                        .foregroundColor(.red)
+                        .frame(width: 325, alignment: .leading)
+                }
+                
+                PasswordFieldView(title: "비밀번호 확인", text: $viewModel.confirmPassword, showPassword: $viewModel.showPassword, focus: $focusedField, field: .confirmPassword)
+                
+                if focusedField != .confirmPassword, !viewModel.confirmPassword.isEmpty && viewModel.password != viewModel.confirmPassword {
+                    Text("비밀번호가 일치하지 않습니다.")
+                        .font(.system(size: 14))
+                        .foregroundColor(.red)
+                        .frame(width: 325, alignment: .leading)
+                }
+                
+                ValidatedInputField(
+                    title: "닉네임",
+                    text: $viewModel.nickname,
+                    onCheckDuplicate: { await viewModel.checkValidateNickname() },
+                    focus: $focusedField,
+                    field: .nickname
+                )
+                
+                if let nicknameCheck = viewModel.nicknameCheckMessage {
+                    Text(nicknameCheck)
+                        .font(.system(size: 14))
+                        .foregroundColor(nicknameCheck == "사용 가능한 닉네임입니다." ? .green : .red)
+                        .frame(width: 325, alignment: .leading)
+                        .padding(.top, 1)
+                }
+                
+                Button(action: {
+                    Task {
+                        await viewModel.signUp()
+                    }
+                }, label: {
+                    HStack {
+                        if viewModel.isSigningUp {
+                            ProgressView()
+                                .tint(.white)
+                                .padding(.trailing, 8)
+                        }
+                        Text("회원가입")
+                    }
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundStyle(.white)
+                    .frame(width: 330, height: 50)
+                    .background(viewModel.isValid() ? Color("LoginBtnColor") : Color.gray)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                })
+                .padding(.top, 16)
+                .disabled(!viewModel.isValid() || viewModel.isSigningUp || viewModel.password != viewModel.confirmPassword)
+                Spacer()
             }
+            .padding(.bottom, 20)
             
-            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button {

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -245,7 +245,7 @@ struct ValidatedInputField: View {
                 .padding(.top, 20)
             
             HStack {
-                TextField("", text: $text)
+                TextField(title, text: $text, prompt: Text(field == .email ? "1 ~ 50자 이내로 입력해 주세요": field == .nickname ? "1 ~ 12자 이내로 입력해 주세요" : ""))
                     .focused(focus, equals: field)
                     .onChange(of: text) { newValue, _ in
                         if newValue.count > maxLength {

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -85,7 +85,6 @@ struct SignUpView: View {
                                 .frame(width: 325, alignment: .leading)
                                 .padding(.top, 1)
                         }
-                        GenderSelectedView(selectedGender: $viewModel.gender)
                         
                         Button(action: {
                             Task {
@@ -238,40 +237,6 @@ struct PasswordFieldView: View {
                     .stroke(focus.wrappedValue == field ? Color("LoginBtnColor") : Color("FontColor"),
                             lineWidth: focus.wrappedValue == field ? 1.2 : 0.6)
                     .animation(.easeInOut(duration: 0.1), value: focus.wrappedValue == field)
-            }
-        }
-        .frame(width: 330, height: 90)
-    }
-}
-
-struct GenderSelectedView: View {
-    @Binding var selectedGender: String
-    let genders: [String] = ["남자", "여자"]
-    
-    var body: some View {
-        VStack {
-            Text("성별")
-                .frame(width: 320, height: 25, alignment: .leading)
-                .font(.system(size: 17))
-            
-            HStack {
-                ForEach(genders, id: \.self) { gender in
-                    Button(action: {
-                        if selectedGender == gender {
-                            selectedGender = ""
-                        } else {
-                            selectedGender = gender
-                        }
-                    }) {
-                        Text(gender)
-                            .foregroundColor(selectedGender == gender ? Color("LoginBtnColor") : Color("FontColor"))
-                            .frame(width: 160, height: 50)
-                    }
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(selectedGender == gender ? Color("LoginBtnColor") : Color("FontColor"), lineWidth: 0.6)
-                    )
-                }
             }
         }
         .frame(width: 330, height: 90)

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -69,10 +69,10 @@ struct SignUpView: View {
                     )
                 case .password:
                     PasswordFieldView(title: "비밀번호를 입력해 주세요.", text: $viewModel.password, showPassword: $viewModel.showPassword, focus: $focusedField, field: .password)
-                    if focusedField != .password, let errorMessage = viewModel.passwordErrorMessage {
+                    if let errorMessage = viewModel.passwordErrorMessage {
                         Text(errorMessage)
                             .font(.system(size: 14))
-                            .foregroundColor(.red)
+                            .foregroundColor(Color("FontColor"))
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.leading, 30)
                             .padding(.top, 10)
@@ -186,7 +186,7 @@ struct PasswordFieldView: View {
                                 if newValue.count > 20 { text = String(newValue.prefix(20)) }
                             }
                     } else {
-                        SecureField("", text: $text)
+                        SecureField(title, text: $text, prompt: Text(field == .password ? "대소문자, 숫자, 특수문자 포함한 8자리 이상" : field == .confirmPassword ? "비밀번호를 다시 입력해 주세요.":""))
                             .focused(focus, equals: field)
                             .onChange(of: text) { newValue, _ in
                                 if newValue.count > 20 { text = String(newValue.prefix(20)) }

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -265,7 +265,6 @@ struct ValidatedInputField: View {
                             text = String(newValue.prefix(maxLength))
                         }
                     }
-                    .frame(width: .infinity)
                     .frame(height: 50)
                     .textInputAutocapitalization(.never)
                     .overlay {
@@ -275,6 +274,7 @@ struct ValidatedInputField: View {
                     }
             }
         }
+        .frame(maxWidth: .infinity)
         .frame(height: 90)
         .padding(.horizontal, 16)
     }

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -19,120 +19,120 @@ struct SignUpView: View {
     @Environment(\.dismiss) private var dismiss
     @FocusState private var focusedField: SignUpFocusField?
     var onSignUpSuccess: (() -> Void)? = nil
-
+    
     var body: some View {
         NavigationStack {
-            VStack {
-                ScrollView {
-                    VStack {
-                        Text("회원가입")
-                            .frame(width: 320, height: 70)
-                            .font(.system(size: 22, weight: .bold))
-                            .padding(.horizontal, 16)
-                        
-                        ValidatedInputField(
-                            title: "이메일",
-                            text: $viewModel.email,
-                            onCheckDuplicate: { await viewModel.checkEmailWithFormatValidation() },
-                            focus: $focusedField,
-                            field: .email
-                        )
-
-                        if let formatMessage = viewModel.emailFormatInvalidMessage {
-                            Text(formatMessage)
-                                .font(.system(size: 14))
-                                .foregroundColor(.red)
-                                .frame(width: 325, alignment: .leading)
-                        }
-
-                        if !viewModel.email.isEmpty, let emailCheck = viewModel.emailCheckMessage {
-                            Text(emailCheck)
-                                .font(.system(size: 14))
-                                .foregroundColor(emailCheck == "사용 가능한 이메일입니다." ? .green : .red)
-                                .frame(width: 330, alignment: .leading)
-                        }
-                        
-                        PasswordFieldView(title: "비밀번호", text: $viewModel.password, showPassword: $viewModel.showPassword, focus: $focusedField, field: .password)
-                        
-                        if focusedField != .password, let errorMessage = viewModel.passwordErrorMessage {
-                            Text(errorMessage)
-                                .font(.system(size: 14))
-                                .foregroundColor(.red)
-                                .frame(width: 325, alignment: .leading)
-                        }
-                        
-                        PasswordFieldView(title: "비밀번호 확인", text: $viewModel.confirmPassword, showPassword: $viewModel.showPassword, focus: $focusedField, field: .confirmPassword)
-                        
-                        if focusedField != .confirmPassword, !viewModel.confirmPassword.isEmpty && viewModel.password != viewModel.confirmPassword {
-                            Text("비밀번호가 일치하지 않습니다.")
-                                .font(.system(size: 14))
-                                .foregroundColor(.red)
-                                .frame(width: 325, alignment: .leading)
-                        }
-                        
-                        ValidatedInputField(
-                            title: "닉네임",
-                            text: $viewModel.nickname,
-                            onCheckDuplicate: { await viewModel.checkValidateNickname() },
-                            focus: $focusedField,
-                            field: .nickname
-                        )
-                        
-                        if let nicknameCheck = viewModel.nicknameCheckMessage {
-                            Text(nicknameCheck)
-                                .font(.system(size: 14))
-                                .foregroundColor(nicknameCheck == "사용 가능한 닉네임입니다." ? .green : .red)
-                                .frame(width: 325, alignment: .leading)
-                                .padding(.top, 1)
-                        }
-                        
-                        Button(action: {
-                            Task {
-                                await viewModel.signUp()
-                            }
-                        }, label: {
-                            HStack {
-                                if viewModel.isSigningUp {
-                                    ProgressView()
-                                        .tint(.white)
-                                        .padding(.trailing, 8)
-                                }
-                                Text("회원가입")
-                            }
-                            .font(.system(size: 18, weight: .bold))
-                            .foregroundStyle(.white)
-                            .frame(width: 330, height: 50)
-                            .background(viewModel.isValid() ? Color("LoginBtnColor") : Color.gray)
-                            .clipShape(RoundedRectangle(cornerRadius: 12))
-                        })
-                        .padding(.top, 16)
-                        .disabled(!viewModel.isValid() || viewModel.isSigningUp || viewModel.password != viewModel.confirmPassword)
-                        Spacer()
+            ScrollView {
+                VStack {
+                    ValidatedInputField(
+                        title: "이메일",
+                        text: $viewModel.email,
+                        onCheckDuplicate: { await viewModel.checkEmailWithFormatValidation() },
+                        focus: $focusedField,
+                        field: .email
+                    )
+                    
+                    if let formatMessage = viewModel.emailFormatInvalidMessage {
+                        Text(formatMessage)
+                            .font(.system(size: 14))
+                            .foregroundColor(.red)
+                            .frame(width: 325, alignment: .leading)
                     }
-                    .padding(.bottom, 20)
+                    
+                    if !viewModel.email.isEmpty, let emailCheck = viewModel.emailCheckMessage {
+                        Text(emailCheck)
+                            .font(.system(size: 14))
+                            .foregroundColor(emailCheck == "사용 가능한 이메일입니다." ? .green : .red)
+                            .frame(width: 330, alignment: .leading)
+                    }
+                    
+                    PasswordFieldView(title: "비밀번호", text: $viewModel.password, showPassword: $viewModel.showPassword, focus: $focusedField, field: .password)
+                    
+                    if focusedField != .password, let errorMessage = viewModel.passwordErrorMessage {
+                        Text(errorMessage)
+                            .font(.system(size: 14))
+                            .foregroundColor(.red)
+                            .frame(width: 325, alignment: .leading)
+                    }
+                    
+                    PasswordFieldView(title: "비밀번호 확인", text: $viewModel.confirmPassword, showPassword: $viewModel.showPassword, focus: $focusedField, field: .confirmPassword)
+                    
+                    if focusedField != .confirmPassword, !viewModel.confirmPassword.isEmpty && viewModel.password != viewModel.confirmPassword {
+                        Text("비밀번호가 일치하지 않습니다.")
+                            .font(.system(size: 14))
+                            .foregroundColor(.red)
+                            .frame(width: 325, alignment: .leading)
+                    }
+                    
+                    ValidatedInputField(
+                        title: "닉네임",
+                        text: $viewModel.nickname,
+                        onCheckDuplicate: { await viewModel.checkValidateNickname() },
+                        focus: $focusedField,
+                        field: .nickname
+                    )
+                    
+                    if let nicknameCheck = viewModel.nicknameCheckMessage {
+                        Text(nicknameCheck)
+                            .font(.system(size: 14))
+                            .foregroundColor(nicknameCheck == "사용 가능한 닉네임입니다." ? .green : .red)
+                            .frame(width: 325, alignment: .leading)
+                            .padding(.top, 1)
+                    }
+                    
+                    Button(action: {
+                        Task {
+                            await viewModel.signUp()
+                        }
+                    }, label: {
+                        HStack {
+                            if viewModel.isSigningUp {
+                                ProgressView()
+                                    .tint(.white)
+                                    .padding(.trailing, 8)
+                            }
+                            Text("회원가입")
+                        }
+                        .font(.system(size: 18, weight: .bold))
+                        .foregroundStyle(.white)
+                        .frame(width: 330, height: 50)
+                        .background(viewModel.isValid() ? Color("LoginBtnColor") : Color.gray)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                    })
+                    .padding(.top, 16)
+                    .disabled(!viewModel.isValid() || viewModel.isSigningUp || viewModel.password != viewModel.confirmPassword)
+                    Spacer()
                 }
-                .scrollIndicators(.hidden)
-                .padding(.horizontal)
+                .padding(.bottom, 20)
             }
+            
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button {
                         dismiss()
                     } label: {
-                        Image(systemName: "xmark")
+                        Image(systemName: "chevron.left")
                             .foregroundStyle(Color("FontColor"))
                     }
                 }
+                ToolbarItem(placement: .principal) {
+                    Text("회원가입")
+                        .font(.system(size: 20, weight: .medium))
+                }
             }
-            // 회원가입 성공 시 NavigationDestination로 SignUpCompleteView로 이동
-            .navigationDestination(isPresented: $viewModel.isSignUpSuccess) {
+            .navigationBarBackButtonHidden(false)
+            .safeAreaInset(edge: .top) {
+                Divider()
+                    .frame(height: 1)
+            }
+            // 회원가입 성공 시 SignUpCompleteView로 이동
+            .sheet(isPresented: $viewModel.isSignUpSuccess) {
                 // onSignUpSuccess를 전달하여 SignUpCompleteView가 완료 시 이를 호출하도록 함
                 SignUpCompleteView(nickname: viewModel.nickname, onComplete: {
                     dismiss()
                     onSignUpSuccess?()
                 })
-                .navigationBarBackButtonHidden(true)
             }
             .errorToast(
                 message: viewModel.generalErrorMessage,
@@ -146,7 +146,9 @@ struct SignUpView: View {
 }
 
 #Preview {
-    SignUpView(onSignUpSuccess: nil)
+    NavigationStack {
+        SignUpView(onSignUpSuccess: nil)
+    }
 }
 
 struct InputFieldView: View {
@@ -214,7 +216,6 @@ struct PasswordFieldView: View {
                     } else {
                         SecureField("", text: $text)
                             .focused(focus, equals: field)
-
                             .onChange(of: text) { newValue, _ in
                                 if newValue.count > 20 { text = String(newValue.prefix(20)) }
                             }
@@ -249,7 +250,7 @@ struct ValidatedInputField: View {
     let onCheckDuplicate: () async -> Void
     var focus: FocusState<SignUpFocusField?>.Binding
     let field: SignUpFocusField
-
+    
     var body: some View {
         let maxLength: Int = {
             switch field {
@@ -271,7 +272,7 @@ struct ValidatedInputField: View {
                     .offset(x: -7)
             }
             .frame(width: 320, height: 25, alignment: .leading)
-
+            
             HStack {
                 TextField("", text: $text)
                     .focused(focus, equals: field)
@@ -288,7 +289,7 @@ struct ValidatedInputField: View {
                             .stroke(focus.wrappedValue == field ? Color("LoginBtnColor") : Color("FontColor"), lineWidth: focus.wrappedValue == field ? 1.2 : 0.6)
                             .animation(.easeInOut(duration: 0.1), value: focus.wrappedValue == field)
                     }
-
+                
                 Button("중복 확인") {
                     Task {
                         await onCheckDuplicate()

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -67,6 +67,14 @@ struct SignUpView: View {
                         focus: $focusedField,
                         field: .email,
                     )
+                    if let emailError = viewModel.emailCheckMessage {
+                        Text(emailError)
+                            .font(.system(size: 14))
+                            .foregroundColor(.red)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 25)
+                            .padding(.top, 10)
+                    }
                 case .password:
                     PasswordFieldView(title: "비밀번호를 입력해 주세요.", text: $viewModel.password, showPassword: $viewModel.showPassword, focus: $focusedField, field: .password)
                     VStack(alignment: .leading, spacing: 6) {
@@ -93,12 +101,13 @@ struct SignUpView: View {
                         focus: $focusedField,
                         field: .nickname
                     )
-                    if let nicknameCheck = viewModel.nicknameCheckMessage {
-                        Text(nicknameCheck)
+                    if let nicknameError = viewModel.nicknameCheckMessage {
+                        Text(nicknameError)
                             .font(.system(size: 14))
-                            .foregroundColor(nicknameCheck == "사용 가능한 닉네임입니다." ? .green : .red)
-                            .frame(width: 325, alignment: .leading)
-                            .padding(.top, 1)
+                            .foregroundColor(.red)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 25)
+                            .padding(.top, 10)
                     }
                 }
                 Spacer()
@@ -107,13 +116,22 @@ struct SignUpView: View {
                     Task {
                         switch step {
                         case .email:
-                            step = .password
+                            // 버튼 클릭 시 이메일 중복 검사
+                            await viewModel.checkEmailWithFormatValidation()
+                            await viewModel.checkValidateEmail()
+                            if viewModel.emailCheckMessage == nil {
+                                step = .password
+                            }
                         case .password:
                             step = .confirmPassword
                         case .confirmPassword:
                             step = .nickname
                         case .nickname:
-                            await viewModel.signUp()
+                            // 버튼 클릭 시 닉네임 중복 검사
+                            await viewModel.checkValidateNickname()
+                            if viewModel.nicknameCheckMessage == nil {
+                                await viewModel.signUp()
+                            }
                         }
                     }
                 }, label: {

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -12,7 +12,6 @@ enum SignUpFocusField: Hashable {
     case password
     case confirmPassword
     case nickname
-    case name
 }
 
 struct SignUpView: View {
@@ -86,8 +85,6 @@ struct SignUpView: View {
                                 .frame(width: 325, alignment: .leading)
                                 .padding(.top, 1)
                         }
-                        
-                        InputFieldView(title: "이름", text: $viewModel.name, focus: $focusedField, field: .name)
                         GenderSelectedView(selectedGender: $viewModel.gender)
                         
                         Button(action: {

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -60,13 +60,12 @@ struct SignUpView: View {
                         }) {
                             Image(systemName: "chevron.left")
                                 .foregroundStyle(Color("FontColor"))
-                                .frame(width: 24, height: 24)
+                                .frame(width: 15, height: 24)
                         }
                         Spacer()
                         Text("회원가입")
                             .font(.system(size: 20, weight: .medium))
                         Spacer()
-                        // 가운데 정렬 보정을 위한 우측 더미 공간 (좌측 버튼과 너비 맞춤)
                         Color.clear
                             .frame(width: 24, height: 24)
                     }
@@ -86,7 +85,7 @@ struct SignUpView: View {
                         field: .email,
                     )
                 case .password:
-                    PasswordFieldView(title: "비밀번호", text: $viewModel.password, showPassword: $viewModel.showPassword, focus: $focusedField, field: .password)
+                    PasswordFieldView(title: "비밀번호를 입력해 주세요.", text: $viewModel.password, showPassword: $viewModel.showPassword, focus: $focusedField, field: .password)
                     if focusedField != .password, let errorMessage = viewModel.passwordErrorMessage {
                         Text(errorMessage)
                             .font(.system(size: 14))
@@ -94,7 +93,7 @@ struct SignUpView: View {
                             .frame(width: 325, alignment: .leading)
                     }
                 case .confirmPassword:
-                    PasswordFieldView(title: "비밀번호 확인", text: $viewModel.confirmPassword, showPassword: $viewModel.showPassword, focus: $focusedField, field: .confirmPassword)
+                    PasswordFieldView(title: "비밀번호를 한 번 더 입력해 주세요.", text: $viewModel.confirmPassword, showPassword: $viewModel.showPassword, focus: $focusedField, field: .confirmPassword)
                     if focusedField != .confirmPassword, !viewModel.confirmPassword.isEmpty && viewModel.password != viewModel.confirmPassword {
                         Text("비밀번호가 일치하지 않습니다.")
                             .font(.system(size: 14))
@@ -134,13 +133,15 @@ struct SignUpView: View {
                     }
                 }, label: {
                     Text(step == .nickname ? "회원가입" : "다음")
-                        .font(.system(size: 16, weight: .semibold))
-                        .frame(maxWidth: 330, minHeight: 48)
+                        .font(.system(size: 18, weight: .semibold))
+                        .frame(maxWidth: .infinity)
+                        .frame(minHeight: 48)
                 })
                 .foregroundStyle(.white)
                 .background(nextEnabled ? Color("LoginBtnColor") : Color.gray)
                 .clipShape(RoundedRectangle(cornerRadius: 12))
                 .disabled(!nextEnabled)
+                .padding(.horizontal, 16)
             }
             .onAppear { focusedField = .email }
             .onChange(of: step) { newStep, _ in
@@ -185,12 +186,11 @@ struct PasswordFieldView: View {
     
     var body: some View {
         VStack {
-            HStack {
                 Text(title)
-                    .font(.system(size: 17))
-            }
-            .frame(width: 320, height: 25, alignment: .leading)
-            
+                    .font(.system(size: 20, weight: .medium))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .frame(height: 30)
+                    .padding(.top, 20)
             HStack {
                 Section {
                     if showPassword {
@@ -207,7 +207,7 @@ struct PasswordFieldView: View {
                             }
                     }
                 }
-                .frame(width: 260, height: 40)
+                .padding(.leading, 13)
                 .textInputAutocapitalization(.never)
                 
                 Button(action: {
@@ -218,7 +218,8 @@ struct PasswordFieldView: View {
                         .foregroundStyle(.gray)
                 })
             }
-            .frame(width: 330, height: 50)
+            .frame(maxWidth: .infinity)
+            .frame(height: 50)
             .overlay {
                 RoundedRectangle(cornerRadius: 13)
                     .stroke(focus.wrappedValue == field ? Color("LoginBtnColor") : Color("FontColor"),
@@ -226,7 +227,8 @@ struct PasswordFieldView: View {
                     .animation(.easeInOut(duration: 0.1), value: focus.wrappedValue == field)
             }
         }
-        .frame(width: 330, height: 90)
+        .frame(height: 90)
+        .padding(.horizontal, 16)
     }
 }
 
@@ -251,20 +253,21 @@ struct ValidatedInputField: View {
         VStack {
             Text(title)
                 .font(.system(size: 20, weight: .medium))
-                .frame(width: 330, height: 30, alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(height: 30)
                 .padding(.top, 20)
-            
             HStack {
-                TextField(title, text: $text, prompt: Text(field == .email ? "1 ~ 50자 이내로 입력해 주세요": field == .nickname ? "1 ~ 12자 이내로 입력해 주세요" : ""))
+                TextField(title, text: $text, prompt: Text(field == .email ? "1 ~ 50자 이내로 입력해 주세요.": field == .nickname ? "1 ~ 12자 이내로 입력해 주세요." : ""))
                     .focused(focus, equals: field)
+                    .padding(.leading, 13)
                     .onChange(of: text) { newValue, _ in
                         if newValue.count > maxLength {
                             text = String(newValue.prefix(maxLength))
                         }
                     }
-                    .frame(width: 300, height: 50)
+                    .frame(width: .infinity)
+                    .frame(height: 50)
                     .textInputAutocapitalization(.never)
-                    .frame(width: 330, height: 50)
                     .overlay {
                         RoundedRectangle(cornerRadius: 12)
                             .stroke(focus.wrappedValue == field ? Color("LoginBtnColor") : Color("FontColor"), lineWidth: focus.wrappedValue == field ? 1.2 : 0.6)
@@ -272,6 +275,7 @@ struct ValidatedInputField: View {
                     }
             }
         }
-        .frame(width: 330, height: 90)
+        .frame(height: 90)
+        .padding(.horizontal, 16)
     }
 }

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -43,8 +43,27 @@ struct SignUpView: View {
     }
     
     var body: some View {
-        NavigationStack {
             VStack {
+                VStack(spacing: 0) {
+                    HStack {
+                        Button(action: { dismiss() }) {
+                            Image(systemName: "chevron.left")
+                                .foregroundStyle(Color("FontColor"))
+                                .frame(width: 24, height: 24)
+                        }
+                        Spacer()
+                        Text("회원가입")
+                            .font(.system(size: 20, weight: .medium))
+                        Spacer()
+                        // 가운데 정렬 보정을 위한 우측 더미 공간 (좌측 버튼과 너비 맞춤)
+                        Color.clear
+                            .frame(width: 24, height: 24)
+                    }
+                    .padding(.horizontal, 16)
+                    .frame(height: 44)
+
+                    Divider().frame(height: 1)
+                }
                 // 현재 스텝에 따라 하나의 입력 화면만 표시
                 switch step {
                 case .email:
@@ -73,7 +92,7 @@ struct SignUpView: View {
                     }
                 case .nickname:
                     ValidatedInputField(
-                        title: "닉네임",
+                        title: "닉네임을 입력해 주세요.",
                         text: $viewModel.nickname,
                         onCheckDuplicate: { await viewModel.checkValidateNickname() },
                         focus: $focusedField,
@@ -121,26 +140,6 @@ struct SignUpView: View {
                 case .nickname: focusedField = .nickname
                 }
             }
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button {
-                        dismiss()
-                    } label: {
-                        Image(systemName: "chevron.left")
-                            .foregroundStyle(Color("FontColor"))
-                    }
-                }
-                ToolbarItem(placement: .principal) {
-                    Text("회원가입")
-                        .font(.system(size: 20, weight: .medium))
-                }
-            }
-            .navigationBarTitleDisplayMode(.inline)
-            .navigationBarBackButtonHidden(false)
-            .safeAreaInset(edge: .top) {
-                Divider()
-                    .frame(height: 1)
-            }
             // 회원가입 성공 시 SignUpCompleteView로 이동
             .sheet(isPresented: $viewModel.isSignUpSuccess) {
                 // onSignUpSuccess를 전달하여 SignUpCompleteView가 완료 시 이를 호출하도록 함
@@ -158,7 +157,7 @@ struct SignUpView: View {
             )
         }
     }
-}
+
 
 #Preview {
     NavigationStack {

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -18,89 +18,108 @@ struct SignUpView: View {
     @State private var viewModel = SignUpViewModel()
     @Environment(\.dismiss) private var dismiss
     @FocusState private var focusedField: SignUpFocusField?
+    // 멀티 스텝 진행 상태
+    private enum Step: Int, CaseIterable { case email, password, confirmPassword, nickname }
+    @State private var step: Step = .email
+    
+    // 회원가입 완료 시 상위 화면으로 성공 콜백 전달
     var onSignUpSuccess: (() -> Void)? = nil
+    
+    // 다음 버튼 활성화 상태
+    private var nextEnabled: Bool { isNextEnabled() }
+    
+    // 다음 버튼 활성화 로직
+    private func isNextEnabled() -> Bool {
+        switch step {
+        case .email:
+            return !viewModel.email.isEmpty && viewModel.isValidEmail(viewModel.email)
+        case .password:
+            return !viewModel.password.isEmpty && viewModel.passwordErrorMessage == nil
+        case .confirmPassword:
+            return !viewModel.confirmPassword.isEmpty && viewModel.password == viewModel.confirmPassword
+        case .nickname:
+            return !viewModel.nickname.isEmpty
+        }
+    }
     
     var body: some View {
         NavigationStack {
             VStack {
-                ValidatedInputField(
-                    title: "이메일",
-                    text: $viewModel.email,
-                    onCheckDuplicate: { await viewModel.checkEmailWithFormatValidation() },
-                    focus: $focusedField,
-                    field: .email
-                )
-                
-                if let formatMessage = viewModel.emailFormatInvalidMessage {
-                    Text(formatMessage)
-                        .font(.system(size: 14))
-                        .foregroundColor(.red)
-                        .frame(width: 325, alignment: .leading)
+                // 현재 스텝에 따라 하나의 입력 화면만 표시
+                switch step {
+                case .email:
+                    ValidatedInputField(
+                        title: "이메일을 입력해 주세요.",
+                        text: $viewModel.email,
+                        onCheckDuplicate: { await viewModel.checkEmailWithFormatValidation() },
+                        focus: $focusedField,
+                        field: .email,
+                    )
+                case .password:
+                    PasswordFieldView(title: "비밀번호", text: $viewModel.password, showPassword: $viewModel.showPassword, focus: $focusedField, field: .password)
+                    if focusedField != .password, let errorMessage = viewModel.passwordErrorMessage {
+                        Text(errorMessage)
+                            .font(.system(size: 14))
+                            .foregroundColor(.red)
+                            .frame(width: 325, alignment: .leading)
+                    }
+                case .confirmPassword:
+                    PasswordFieldView(title: "비밀번호 확인", text: $viewModel.confirmPassword, showPassword: $viewModel.showPassword, focus: $focusedField, field: .confirmPassword)
+                    if focusedField != .confirmPassword, !viewModel.confirmPassword.isEmpty && viewModel.password != viewModel.confirmPassword {
+                        Text("비밀번호가 일치하지 않습니다.")
+                            .font(.system(size: 14))
+                            .foregroundColor(.red)
+                            .frame(width: 325, alignment: .leading)
+                    }
+                case .nickname:
+                    ValidatedInputField(
+                        title: "닉네임",
+                        text: $viewModel.nickname,
+                        onCheckDuplicate: { await viewModel.checkValidateNickname() },
+                        focus: $focusedField,
+                        field: .nickname
+                    )
+                    if let nicknameCheck = viewModel.nicknameCheckMessage {
+                        Text(nicknameCheck)
+                            .font(.system(size: 14))
+                            .foregroundColor(nicknameCheck == "사용 가능한 닉네임입니다." ? .green : .red)
+                            .frame(width: 325, alignment: .leading)
+                            .padding(.top, 1)
+                    }
                 }
-                
-                if !viewModel.email.isEmpty, let emailCheck = viewModel.emailCheckMessage {
-                    Text(emailCheck)
-                        .font(.system(size: 14))
-                        .foregroundColor(emailCheck == "사용 가능한 이메일입니다." ? .green : .red)
-                        .frame(width: 330, alignment: .leading)
-                }
-                
-                PasswordFieldView(title: "비밀번호", text: $viewModel.password, showPassword: $viewModel.showPassword, focus: $focusedField, field: .password)
-                
-                if focusedField != .password, let errorMessage = viewModel.passwordErrorMessage {
-                    Text(errorMessage)
-                        .font(.system(size: 14))
-                        .foregroundColor(.red)
-                        .frame(width: 325, alignment: .leading)
-                }
-                
-                PasswordFieldView(title: "비밀번호 확인", text: $viewModel.confirmPassword, showPassword: $viewModel.showPassword, focus: $focusedField, field: .confirmPassword)
-                
-                if focusedField != .confirmPassword, !viewModel.confirmPassword.isEmpty && viewModel.password != viewModel.confirmPassword {
-                    Text("비밀번호가 일치하지 않습니다.")
-                        .font(.system(size: 14))
-                        .foregroundColor(.red)
-                        .frame(width: 325, alignment: .leading)
-                }
-                
-                ValidatedInputField(
-                    title: "닉네임",
-                    text: $viewModel.nickname,
-                    onCheckDuplicate: { await viewModel.checkValidateNickname() },
-                    focus: $focusedField,
-                    field: .nickname
-                )
-                
-                if let nicknameCheck = viewModel.nicknameCheckMessage {
-                    Text(nicknameCheck)
-                        .font(.system(size: 14))
-                        .foregroundColor(nicknameCheck == "사용 가능한 닉네임입니다." ? .green : .red)
-                        .frame(width: 325, alignment: .leading)
-                        .padding(.top, 1)
-                }
-                
+                Spacer()
+                // 다음/회원가입 버튼
                 Button(action: {
                     Task {
-                        await viewModel.signUp()
+                        switch step {
+                        case .email:
+                            step = .password
+                        case .password:
+                            step = .confirmPassword
+                        case .confirmPassword:
+                            step = .nickname
+                        case .nickname:
+                            await viewModel.signUp()
+                        }
                     }
                 }, label: {
-                    HStack {
-                        if viewModel.isSigningUp {
-                            ProgressView()
-                                .tint(.white)
-                                .padding(.trailing, 8)
-                        }
-                        Text("회원가입")
-                    }
-                    .font(.system(size: 18, weight: .bold))
-                    .foregroundStyle(.white)
-                    .frame(width: 330, height: 50)
-                    .background(viewModel.isValid() ? Color("LoginBtnColor") : Color.gray)
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    Text(step == .nickname ? "회원가입" : "다음")
+                        .font(.system(size: 16, weight: .semibold))
+                        .frame(maxWidth: 330, minHeight: 48)
                 })
-                .padding(.top, 16)
-                .disabled(!viewModel.isValid() || viewModel.isSigningUp || viewModel.password != viewModel.confirmPassword)
-                Spacer()
+                .foregroundStyle(.white)
+                .background(nextEnabled ? Color("LoginBtnColor") : Color.gray)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .disabled(!nextEnabled)
+            }
+            .onAppear { focusedField = .email }
+            .onChange(of: step) { newStep, _ in
+                switch newStep {
+                case .email: focusedField = .email
+                case .password: focusedField = .password
+                case .confirmPassword: focusedField = .confirmPassword
+                case .nickname: focusedField = .nickname
+                }
             }
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
@@ -147,41 +166,6 @@ struct SignUpView: View {
     }
 }
 
-struct InputFieldView: View {
-    let title: String
-    @Binding var text: String
-    var focus: FocusState<SignUpFocusField?>.Binding
-    let field: SignUpFocusField
-    
-    var body: some View {
-        VStack {
-            HStack {
-                Text(title)
-                    .font(.system(size: 17))
-            }
-            .frame(width: 320, height: 25, alignment: .leading)
-            
-            TextField("", text: $text)
-                .focused(focus, equals: field)
-                .onChange(of: text){ newValue, _ in
-                    if newValue.count > 20 {
-                        text = String(newValue.prefix(20))
-                    }
-                }
-                .frame(width: 300, height: 50)
-                .textInputAutocapitalization(.never)    // 첫 글자 대문자 표출 X
-                .frame(width: 330, height: 50)
-                .overlay {
-                    RoundedRectangle(cornerRadius: 12)
-                        .stroke(focus.wrappedValue == field ? Color("LoginBtnColor") : Color("FontColor"),
-                                lineWidth: focus.wrappedValue == field ? 1.2 : 0.6)
-                        .animation(.easeInOut(duration: 0.15), value: focus.wrappedValue == field)
-                }
-        }
-        .frame(width: 330, height: 90)
-    }
-}
-
 struct PasswordFieldView: View {
     let title: String
     @Binding var text: String
@@ -194,10 +178,6 @@ struct PasswordFieldView: View {
             HStack {
                 Text(title)
                     .font(.system(size: 17))
-                Text("*")
-                    .font(.system(size: 20))
-                    .foregroundStyle(.red)
-                    .offset(x: -7)
             }
             .frame(width: 320, height: 25, alignment: .leading)
             
@@ -259,15 +239,10 @@ struct ValidatedInputField: View {
             }
         }()
         VStack {
-            HStack {
-                Text(title)
-                    .font(.system(size: 17))
-                Text("*")
-                    .font(.system(size: 20))
-                    .foregroundStyle(.red)
-                    .offset(x: -7)
-            }
-            .frame(width: 320, height: 25, alignment: .leading)
+            Text(title)
+                .font(.system(size: 20, weight: .medium))
+                .frame(width: 330, height: 30, alignment: .leading)
+                .padding(.top, 20)
             
             HStack {
                 TextField("", text: $text)
@@ -277,27 +252,14 @@ struct ValidatedInputField: View {
                             text = String(newValue.prefix(maxLength))
                         }
                     }
-                    .frame(width: 210, height: 50)
+                    .frame(width: 300, height: 50)
                     .textInputAutocapitalization(.never)
-                    .frame(width: 240, height: 50)
+                    .frame(width: 330, height: 50)
                     .overlay {
                         RoundedRectangle(cornerRadius: 12)
                             .stroke(focus.wrappedValue == field ? Color("LoginBtnColor") : Color("FontColor"), lineWidth: focus.wrappedValue == field ? 1.2 : 0.6)
                             .animation(.easeInOut(duration: 0.1), value: focus.wrappedValue == field)
                     }
-                
-                Button("중복 확인") {
-                    Task {
-                        await onCheckDuplicate()
-                    }
-                }
-                .font(.system(size: 14, weight: .medium))
-                .foregroundColor(CHColors.Button.primary)
-                .frame(width: 80, height: 50)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12)
-                        .stroke(CHColors.Button.primary, lineWidth: 1)
-                )
             }
         }
         .frame(width: 330, height: 90)

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -46,7 +46,18 @@ struct SignUpView: View {
             VStack {
                 VStack(spacing: 0) {
                     HStack {
-                        Button(action: { dismiss() }) {
+                        Button(action: {
+                            switch step {
+                            case .email:
+                                dismiss() // 첫 단계에서는 실제 뒤로가기(닫기)
+                            case .password:
+                                step = .email
+                            case .confirmPassword:
+                                step = .password
+                            case .nickname:
+                                step = .confirmPassword
+                            }
+                        }) {
                             Image(systemName: "chevron.left")
                                 .foregroundStyle(Color("FontColor"))
                                 .frame(width: 24, height: 24)

--- a/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
@@ -74,6 +74,41 @@ class SignUpViewModel {
         }
     }
     
+    // 이메일 중복 검사 (RPC 사용)
+    @MainActor
+    func checkValidateEmail() async {
+        let trimmed = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        do {
+            let client = SupabaseConfig.shared.client
+            let params: [String: AnyJSON] = [
+                "p_email": .string(trimmed)
+            ]
+            let response = try await client
+                .rpc("check_email_available", params: params)
+                .execute()
+            
+            let data = response.data
+            guard !data.isEmpty else {
+                self.emailAvailable = false
+                self.emailCheckMessage = "이메일 확인 실패: 빈 응답"
+                return
+            }
+            
+            if let available = try? JSONDecoder().decode(Bool.self, from: data) {
+                self.emailAvailable = available
+                self.emailCheckMessage = available ? nil : "이미 사용 중인 이메일이에요."
+                return
+            }
+            
+            self.emailAvailable = false
+            self.emailCheckMessage = "이메일 확인 실패: 응답 형식 오류"
+        } catch {
+            self.emailAvailable = false
+            self.emailCheckMessage = "이메일 확인 실패: \(error.localizedDescription)"
+        }
+    }
+    
     // 닉네임 중복 검사 (RPC 사용)
     @MainActor
     func checkValidateNickname() async {
@@ -100,7 +135,7 @@ class SignUpViewModel {
             // 단일 Bool (true/false)
             if let available = try? JSONDecoder().decode(Bool.self, from: data) {
                 self.nicknameAvailable = available
-                self.nicknameCheckMessage = available ? "사용 가능한 닉네임입니다." : "이미 사용 중인 닉네임입니다."
+                self.nicknameCheckMessage = available ? nil : "이미 사용 중인 닉네임이에요."
                 return
             }
             

--- a/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
@@ -41,7 +41,6 @@ class SignUpViewModel {
     var password: String = ""
     var confirmPassword: String = ""
     var nickname: String = ""
-    var genres: [String] = []
     var showPassword: Bool = false
     
     // 상태 및 오류 메시지
@@ -53,15 +52,6 @@ class SignUpViewModel {
     var isSignUpSuccess: Bool = false
     var isSigningUp: Bool = false
     var generalErrorMessage: String? = nil
-    
-//    // 필수 필드 채워져 있는지 검사 및 중복검사 결과에 따른 회원가입 버튼 활성화
-//    func isValid() -> Bool {
-//        let validEmail = isValidEmail(email)
-//        let (validPassword, _) = isValidPassword(password)
-//        let confirmPasswordMatch = !confirmPassword.isEmpty && password == confirmPassword
-//        return !email.isEmpty && !password.isEmpty && !confirmPassword.isEmpty && !nickname.isEmpty &&
-//        validEmail && validPassword && confirmPasswordMatch && nicknameAvailable
-//    }
     
     // 이메일 정규식 검사 함수
     func isValidEmail(_ email: String) -> Bool {

--- a/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
@@ -19,6 +19,20 @@ enum PasswordValidationError: String {
     case special = "특수문자를 최소 1개 포함해야 합니다."
 }
 
+extension SignUpViewModel {
+    func isNextEnabled(step: SignUpStep) -> Bool {
+        switch step {
+        case .email:
+            return !email.isEmpty && isValidEmail(email)
+        case .password:
+            return !password.isEmpty && passwordErrorMessage == nil
+        case .confirmPassword:
+            return !confirmPassword.isEmpty && password == confirmPassword
+        case .nickname:
+            return !nickname.isEmpty
+        }
+    }
+}
 
 @Observable
 class SignUpViewModel {

--- a/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
@@ -27,7 +27,6 @@ class SignUpViewModel {
     var password: String = ""
     var confirmPassword: String = ""
     var nickname: String = ""
-    var gender: String = ""
     var genres: [String] = []
     var showPassword: Bool = false
     
@@ -143,14 +142,12 @@ class SignUpViewModel {
         isSigningUp = true
         defer { isSigningUp = false }
         generalErrorMessage = nil
-        let convertedGender = (gender == "남자") ? "MALE" : "FEMALE"
         
         do {
             let client = SupabaseConfig.shared.client
             
             let metadata: [String: AnyJSON] = [
-                "nickname": .string(nickname),
-                "gender": .string(convertedGender)
+                "nickname": .string(nickname)
             ]
             
             // Supabase Auth 회원가입

--- a/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
@@ -10,27 +10,27 @@ import Supabase
 import Auth
 import PostgREST
 
-enum PasswordValidationError: String {
-    case space = "공백 문자는 사용할 수 없습니다."
-    case length = "비밀번호는 8~20자여야 합니다."
-    case upper = "대문자를 최소 1개 포함해야 합니다."
-    case lower = "소문자를 최소 1개 포함해야 합니다."
-    case digit = "숫자를 최소 1개 포함해야 합니다."
-    case special = "특수문자를 최소 1개 포함해야 합니다."
-}
-
 extension SignUpViewModel {
     func isNextEnabled(step: SignUpStep) -> Bool {
         switch step {
         case .email:
             return !email.isEmpty && isValidEmail(email)
         case .password:
-            return !password.isEmpty && passwordErrorMessage == nil
+            // 비밀번호 입력란이 비어 있지 않고, 체크리스트 조건 중 최소 한 가지 이상은 충족해야 다음 단계로 이동 가능
+            return !password.isEmpty && passwordChecks.allSatisfy { $0.passed }
         case .confirmPassword:
             return !confirmPassword.isEmpty && password == confirmPassword
         case .nickname:
             return !nickname.isEmpty
         }
+    }
+    var passwordChecks: [(title: String, passed: Bool)] {
+        [
+            ("8자 이상 입력해 주세요.", password.count >= 8),
+            ("대소문자를 포함해 주세요.", password.range(of: "[A-Z]", options: .regularExpression) != nil &&
+             password.range(of: "[a-z]", options: .regularExpression) != nil),
+            ("숫자 및 특수문자를 포함해 주세요.", password.range(of: "[0-9][!@#$%^&*(),.?\\\":{}|<>]", options: .regularExpression) != nil),
+        ]
     }
 }
 
@@ -54,41 +54,14 @@ class SignUpViewModel {
     var isSigningUp: Bool = false
     var generalErrorMessage: String? = nil
     
-    // 필수 필드 채워져 있는지 검사 및 중복검사 결과에 따른 회원가입 버튼 활성화
-    func isValid() -> Bool {
-        let validEmail = isValidEmail(email)
-        let (validPassword, _) = isValidPassword(password)
-        let confirmPasswordMatch = !confirmPassword.isEmpty && password == confirmPassword
-        return !email.isEmpty && !password.isEmpty && !confirmPassword.isEmpty && !nickname.isEmpty &&
-        validEmail && validPassword && confirmPasswordMatch && nicknameAvailable
-    }
-    
-    // 비밀번호 유효성 검사: 영문 대소문자, 숫자, 특수문자 포함 8~20자, 공백 불가
-    func isValidPassword(_ password: String) -> (Bool, PasswordValidationError?) {
-        if password.contains(where: { $0.isWhitespace }) {
-            return (false, .space)
-        }
-        if password.count < 8 || password.count > 20 {
-            return (false, .length)
-        }
-        if password.range(of: "[A-Z]", options: .regularExpression) == nil {
-            return (false, .upper)
-        }
-        if password.range(of: "[a-z]", options: .regularExpression) == nil {
-            return (false, .lower)
-        }
-        if password.range(of: "[0-9]", options: .regularExpression) == nil {
-            return (false, .digit)
-        }
-        if password.range(of: "[!@#$%^&*(),.?\":{}|<>]", options: .regularExpression) == nil {
-            return (false, .special)
-        }
-        return (true, nil)
-    }
-    
-    var passwordErrorMessage: String? {
-        return isValidPassword(password).1?.rawValue
-    }
+//    // 필수 필드 채워져 있는지 검사 및 중복검사 결과에 따른 회원가입 버튼 활성화
+//    func isValid() -> Bool {
+//        let validEmail = isValidEmail(email)
+//        let (validPassword, _) = isValidPassword(password)
+//        let confirmPasswordMatch = !confirmPassword.isEmpty && password == confirmPassword
+//        return !email.isEmpty && !password.isEmpty && !confirmPassword.isEmpty && !nickname.isEmpty &&
+//        validEmail && validPassword && confirmPasswordMatch && nicknameAvailable
+//    }
     
     // 이메일 정규식 검사 함수
     func isValidEmail(_ email: String) -> Bool {

--- a/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
@@ -26,7 +26,6 @@ class SignUpViewModel {
     var email: String = ""
     var password: String = ""
     var confirmPassword: String = ""
-    var name: String = ""
     var nickname: String = ""
     var gender: String = ""
     var genres: [String] = []
@@ -151,7 +150,6 @@ class SignUpViewModel {
             
             let metadata: [String: AnyJSON] = [
                 "nickname": .string(nickname),
-                "name": .string(name),
                 "gender": .string(convertedGender)
             ]
             


### PR DESCRIPTION
## 작업한 내용
- 회원가입 플로우를 멀티스텝 UI로 분리(이메일/비밀번호/비밀번호 확인/닉네임)
- UI 개선(좌우 16pt 여백 적용)
- 이메일/닉네임 중복 검사 로직 추가
- 비밀번호 체크리스트 UI 추가

## PR Point
- 클라이언트에서 이메일/닉네임 중복 검사 시 Supabase RPC 호출 구조 확인 필요

### 추후 작업할 내용 (미완성 부분)
<!-- 이슈 번호와 함께 향후 작업 예정인 내용을 작성해주세요 -->
<!-- 연결된 이슈가 있다면 작성해주세요 (예: #123) -->
<!-- 체크리스트 작성 (예: - [ ]) -->
X

## 스크린샷
<!-- UI 변경이 있는 경우 변경 전/후 스크린샷을 첨부해주세요 -->
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/17d038a3-187c-439a-8cd8-ad86795d493c" width="200"/><br>
      <p>이메일 중복 검사 시 오류 메시지</p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/758f34bd-1fdc-4d42-ac81-315f910bab53" width="200"/><br>
      <p>비밀번호 입력</p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/78c28adf-bfa5-49c5-8aba-1c8e7c7502cb" width="200"/><br>
      <p>비밀번호 확인</p>
    </td>
      <td>
      <img src="https://github.com/user-attachments/assets/c6f63ae0-c500-4b4d-8339-6f4e11bc4a7f" width="200"/><br>
      <p>닉네임 중복 검사 시 오류 메시지</p>
    </td>
  </tr>
</table> 
