### PR TITLE
[refactor/auth]: Auth 인증 관련 로직 및 구조 전반 리팩토링

### DIFF
--- a/CineHive/CineHive.xcodeproj/project.pbxproj
+++ b/CineHive/CineHive.xcodeproj/project.pbxproj
@@ -384,6 +384,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = CineHive/CineHive.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"CineHive/Resources/Preview Content\"";
@@ -420,6 +421,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = CineHive/CineHive.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"CineHive/Resources/Preview Content\"";

--- a/CineHive/CineHive/App/CineHiveApp.swift
+++ b/CineHive/CineHive/App/CineHiveApp.swift
@@ -11,6 +11,7 @@ import KakaoSDKAuth
 import NaverThirdPartyLogin
 import GoogleSignIn
 import OSLog
+import Supabase
 
 @main
 struct CineHiveApp: App {
@@ -43,17 +44,28 @@ struct CineHiveApp: App {
         WindowGroup {
             // onOpenURL()을 사용해 커스텀 URL 스킴 처리
             ContentView().onOpenURL(perform: { url in
-                if AuthApi.isKakaoTalkLoginUrl(url) {
-                    // Kakao 로그인 URL
+                if let appScheme = URL(string: SupabaseConfig.Auth.appRedirect)?.scheme,
+                   url.scheme == appScheme {
+                    Task {
+                        do {
+                            try await SupabaseConfig.shared.client.auth.session(from: url)
+                            Logger.log(.info, category: Logger.auth, message: "Supabase OAuth 세션 설정 완료: \(url)")
+                        } catch {
+                            print("[OAuth] session(from:) error:", error)
+                        }
+                    }
+                } else if AuthApi.isKakaoTalkLoginUrl(url) {
+                    // Kakao 로그인 URL (SDK 직접 사용 시)
                     AuthController.handleOpenUrl(url: url)
-                } else if url.scheme == Bundle.main.object(forInfoDictionaryKey: "NAVER_URL_SCHEME") as? String,
-                          url.host == "oauth" {
-                    // Naver 로그인 URL
+                } else if url.scheme == (Bundle.main.object(forInfoDictionaryKey: "NAVER_URL_SCHEME") as? String),
+                          (url.host == "oauth" || url.host == "thirdPartyLoginResult") {
+                    // Naver 로그인 URL (앱/브라우저 콜백 모두 처리)
                     NaverThirdPartyLoginConnection.getSharedInstance()?.receiveAccessToken(url)
                 } else if url.scheme?.hasPrefix("com.googleusercontent.apps") == true {
                     // Google 로그인 URL
                     _ = GIDSignIn.sharedInstance.handle(url)
                 } else {
+                    print("[OAuth] Unhandled URL:", url.absoluteString)
                     Logger.log(.info, category: Logger.auth, message: "처리되지 않은 URL: \(url)")
                 }
             })

--- a/CineHive/CineHive/CineHive.entitlements
+++ b/CineHive/CineHive/CineHive.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/CineHive/CineHive/Core/Models/DTO/Auth/AuthSignUpRequest.swift
+++ b/CineHive/CineHive/Core/Models/DTO/Auth/AuthSignUpRequest.swift
@@ -6,9 +6,19 @@
 //
 
 import Foundation
+import Supabase
 
 // 소셜 회원 가입 요청 DTO
 struct AuthSignUpRequest: Encodable {
     let email: String
     let password: String
+    let data: [String: AnyJSON]
+    
+    init(email: String, password: String, nickname: String) {
+        self.email = email
+        self.password = password
+        self.data = [
+            "nickname": .string(nickname)
+        ]
+    }
 }

--- a/CineHive/CineHive/Core/Models/DTO/Auth/AuthSignUpRequest.swift
+++ b/CineHive/CineHive/Core/Models/DTO/Auth/AuthSignUpRequest.swift
@@ -1,5 +1,5 @@
 //
-//  SignUpRequest.swift
+//  AuthSignUpRequest.swift
 //  CineHive
 //
 //  Created by 존진 on 9/17/25.

--- a/CineHive/CineHive/Core/Models/Domain/Profile.swift
+++ b/CineHive/CineHive/Core/Models/Domain/Profile.swift
@@ -43,21 +43,6 @@ struct Profile: Codable {
     }
 }
 
-struct LoginUser: Codable {
-    let email: String
-    let password: String
-    
-    init(email: String, password: String) {
-        self.email = email
-        self.password = password
-    }
-    
-    enum CodingKeys: String, CodingKey {
-        case email
-        case password
-    }
-}
-
 struct LoginResponse: Codable {
     let message: String?
     let user: UserData
@@ -122,13 +107,4 @@ struct ErrorDetail: Codable {
     let field: String
     let rejectedValue: String
     let reason: String
-}
-
-struct AvailabilityResponse: Decodable {
-    let success: Bool
-    let data: AvailabilityData
-}
-
-struct AvailabilityData: Decodable {
-    let isAvailable: Bool
 }

--- a/CineHive/CineHive/Core/Network/EndPoint.swift
+++ b/CineHive/CineHive/Core/Network/EndPoint.swift
@@ -19,7 +19,7 @@ enum ServerEnvironment {
     var baseURL: String {
         switch self {
         case .development:
-            return "http://localhost:8081"
+            return "http://localhost:3000"
         case .staging:
             return "https://staging.api.cinehive.com"
         case .production:
@@ -147,30 +147,30 @@ enum EndPoint {
     }
 
     enum GoogleAuth {
-        static let redirect = "/api/auth/google"
-        static let success = "/api/auth/google/success"
-        static let loginSuccess = "/api/auth/google/login/success"
-        static let callback = "/api/auth/google/callback"
-        static let register = "/api/auth/google/register"
-        static let appLogin = "/api/v1/oauth2/app/login/google"
+        static let redirect = "/api/auth/google"                           // Deprecated
+        static let success = "/api/auth/google/success"                    // Deprecated
+        static let loginSuccess = "/api/auth/google/login/success"         // Deprecated
+        static let callback = "/api/auth/google/callback"                  // Deprecated
+        static let register = "/api/auth/google/register"                  // Deprecated
+        static let appLogin = "/api/v1/oauth2/app/login/google"            // Deprecated
     }
 
     enum NaverAuth {
-        static let redirect = "/api/auth/naver"
-        static let success = "/api/auth/naver/success"
-        static let loginSuccess = "/api/auth/naver/login/success"
-        static let callback = "/api/auth/naver/callback"
-        static let register = "/api/auth/naver/register"
-        static let appLogin = "/api/v1/oauth2/app/login/naver"
+        static let redirect = "/api/auth/naver"                            // Deprecated
+        static let success = "/api/auth/naver/success"                     // Deprecated
+        static let loginSuccess = "/api/auth/naver/login/success"          // Deprecated
+        static let callback = "/api/auth/naver/callback"                   // Deprecated
+        static let register = "/api/auth/naver/register"                   // Deprecated
+        static let appLogin = "/api/v1/oauth2/app/login/naver"             // Deprecated
     }
 
     enum KakaoAuth {
-        static let redirect = "/api/auth/kakao"
-        static let success = "/api/auth/kakao/success"
-        static let loginSuccess = "/api/auth/kakao/login/success"
-        static let callback = "/api/auth/kakao/callback"
-        static let register = "/api/auth/kakao/register"
-        static let appLogin = "/api/v1/oauth2/app/login/kakao"
+        static let redirect = "/api/auth/kakao"                            // Deprecated
+        static let success = "/api/auth/kakao/success"                     // Deprecated
+        static let loginSuccess = "/api/auth/kakao/login/success"          // Deprecated
+        static let callback = "/api/auth/kakao/callback"                   // Deprecated
+        static let register = "/api/auth/kakao/register"                   // Deprecated
+        static let appLogin = "/api/v1/oauth2/app/login/kakao"             // Deprecated
     }
 }
 

--- a/CineHive/CineHive/Core/Network/SupabaseConfig.swift
+++ b/CineHive/CineHive/Core/Network/SupabaseConfig.swift
@@ -22,4 +22,9 @@ class SupabaseConfig {
         self.client = SupabaseClient(supabaseURL: URL(string: supabaseURL)!,
                                      supabaseKey: supabaseKey)
     }
+    // MARK: - Auth Redirect
+    enum Auth {
+        /// 앱 복귀용 URL (Info.plist의 URL Schemes에 등록된 값)
+        static let appRedirect = "cinehive://auth-callback"
+    }
 }

--- a/CineHive/CineHive/Core/Network/SupabaseManager.swift
+++ b/CineHive/CineHive/Core/Network/SupabaseManager.swift
@@ -1,0 +1,96 @@
+//
+//  SupabaseManager.swift
+//  CineHive
+//
+//  Created by 존진 on 10/15/25.
+//
+
+import Foundation
+import Supabase
+
+final class SupabaseManager {
+    static let shared = SupabaseManager()
+    private init() {}
+    
+    let client = SupabaseConfig.shared.client
+    var auth: AuthClient { client.auth }
+
+    // MARK: - PostgREST
+
+    /// SELECT
+    @discardableResult
+    func selectRaw(
+        _ table: String,
+        columns: String = "*",
+        filter: ((PostgrestFilterBuilder) -> PostgrestFilterBuilder)? = nil
+    ) async throws -> Data {
+        let base = client.from(table).select(columns)
+        let fb = filter?(base) ?? base
+        let res = try await fb.execute()
+        return res.data
+    }
+
+    /// INSERT
+    @discardableResult
+    func insertRaw(
+        _ table: String,
+        values: [[String: AnyJSON]],
+        returning: PostgrestReturningOptions = .representation
+    ) async throws -> Data {
+        let res = try await client
+            .from(table)
+            .insert(values, returning: returning)
+            .execute()
+        return res.data
+    }
+
+    /// UPDATE
+    @discardableResult
+    func updateRaw(
+        _ table: String,
+        values: [String: AnyJSON],
+        filter: (PostgrestFilterBuilder) -> PostgrestFilterBuilder,
+        returning: PostgrestReturningOptions = .representation
+    ) async throws -> Data {
+        let qb = try client.from(table).update(values, returning: returning)
+        let res = try await filter(qb).execute()
+        return res.data
+    }
+
+    /// DELETE
+    @discardableResult
+    func deleteRaw(
+        _ table: String,
+        filter: (PostgrestFilterBuilder) -> PostgrestFilterBuilder,
+        returning: PostgrestReturningOptions = .minimal
+    ) async throws -> Data {
+        let qb = client.from(table).delete(returning: returning)
+        let res = try await filter(qb).execute()
+        return res.data
+    }
+
+    /// RPC
+    @discardableResult
+    func callRPC(
+        _ fn: String,
+        params: [String: AnyJSON] = [:]
+    ) async throws -> Data {
+        let res = try await client.rpc(fn, params: params).execute()
+        return res.data
+    }
+    
+    func callRPCBool(_ fn: String, params: [String: AnyJSON] = [:]) async throws -> Bool {
+        let data = try await callRPC(fn, params: params)
+        return (try? decode(data, as: Bool.self)) ?? false
+    }
+
+    // MARK: - Decoding
+
+    func decode<T: Decodable>(_ data: Data, as: T.Type, decoder: JSONDecoder = JSONDecoder()) throws -> T {
+        try decoder.decode(T.self, from: data)
+    }
+
+    func decodeArray<T: Decodable>(_ data: Data, as: T.Type, decoder: JSONDecoder = JSONDecoder()) throws -> [T] {
+        try decoder.decode([T].self, from: data)
+    }
+}

--- a/CineHive/CineHive/Core/State/UserState.swift
+++ b/CineHive/CineHive/Core/State/UserState.swift
@@ -9,6 +9,7 @@ import Foundation
 import SwiftUI
 import Observation
 import OSLog
+import Supabase
 
 @Observable
 final class UserState {
@@ -173,15 +174,23 @@ final class UserState {
         self.currentUser = user
     }
     
-    // 로그아웃 처리 (게스트 모드도 종료)
+    // 로그아웃 처리
     @MainActor
     func logout() {
         let userEmail = currentUser?.email ?? "Unknown"
         Logger.log(.info, category: Logger.auth, message: "로그아웃 요청: \(userEmail)")
-        AuthManager.shared.logout()
-        self.currentUser = nil
-        self.isLoggedIn = false
-        self.isGuestMode = false
+        Task {
+            // Supabase 세션 종료
+            do {
+                try await SupabaseConfig.shared.client.auth.signOut()
+                Logger.log(.info, category: Logger.auth, message: "Supabase 세션 로그아웃 완료")
+                self.currentUser = nil
+                self.isLoggedIn = false
+                self.isGuestMode = false
+            } catch {
+                Logger.log(.error, category: Logger.auth, message: "Supabase 세션 로그아웃 실패: \(error.localizedDescription)")
+            }
+        }
     }
     
     /// 회원가입 처리

--- a/CineHive/CineHive/Core/State/UserState.swift
+++ b/CineHive/CineHive/Core/State/UserState.swift
@@ -66,50 +66,6 @@ final class UserState {
     
     // MARK: - 로그인 관련 메소드
     
-    /// 이메일/비밀번호 로그인 처리
-    @MainActor
-    func login(email: String, password: String) async -> Bool {
-        isLoading = true
-        errorMessage = nil
-        
-        do {
-            let loginData = LoginUser(email: email, password: password)
-            let response = try await UserService.shared.loginUser(user: loginData)
-            
-            // 응답 정보 유효성 확인
-            guard !response.token.isEmpty, response.user.email.count > 0, response.user.nickname.count > 0 else {
-                self.errorMessage = "서버에서 올바른 사용자 정보를 받지 못했습니다"
-                self.isLoading = false
-                Logger.log(.error, category: Logger.auth, message: "로그인 응답 데이터 불완전: \(response)")
-                return false
-            }
-            
-            // JWT 토큰과 사용자 정보 저장
-            AuthManager.shared.saveToken(response.token)
-            AuthManager.shared.saveUser(response.user)
-            // 키체인에 저장된 토큰 값 확인
-            AuthManager.shared.debugPrintToken()
-            
-            // 상태 업데이트
-            self.currentUser = response.user
-            self.isLoggedIn = true
-            self.isLoading = false
-            
-            Logger.log(.info, category: Logger.auth, message: "로그인 성공: \(email), 닉네임: \(response.user.nickname)")
-            return true
-        } catch let error as NetworkError {
-            self.errorMessage = error.localizedDescription
-            self.isLoading = false
-            Logger.log(.error, category: Logger.auth, message: "로그인 실패: \(error.localizedDescription)")
-            return false
-        } catch {
-            self.errorMessage = "로그인 중 오류가 발생했습니다"
-            self.isLoading = false
-            Logger.log(.error, category: Logger.auth, message: "로그인 실패: \(error.localizedDescription)")
-            return false
-        }
-    }
-    
     /// 소셜 로그인 처리
     @MainActor
     func socialLogin(provider: SocialLoginProvider, token: String) async -> SocialLoginResult {
@@ -190,61 +146,6 @@ final class UserState {
             } catch {
                 Logger.log(.error, category: Logger.auth, message: "Supabase 세션 로그아웃 실패: \(error.localizedDescription)")
             }
-        }
-    }
-    
-    /// 회원가입 처리
-    @MainActor
-    func signUp(user: AuthSignUpRequest) async -> Bool {
-        isLoading = true
-        errorMessage = nil
-        
-        do {
-            let response = try await UserService.shared.registerUser(user: user)
-            isLoading = false
-            
-            if response.success == true {
-                Logger.log(.info, category: Logger.auth, message: "회원가입 성공: \(response.data.message)")
-                return true
-            } else {
-                self.errorMessage = response.error?.message
-                Logger.log(.error, category: Logger.auth, message: "회원가입 실패: \(String(describing: errorMessage))")
-                return false
-            }
-        } catch let error as NetworkError {
-            self.errorMessage = error.localizedDescription
-            self.isLoading = false
-            Logger.log(.error, category: Logger.auth, message: "회원가입 실패: \(error.localizedDescription)")
-            return false
-        } catch {
-            self.errorMessage = "회원가입 중 오류가 발생했습니다"
-            self.isLoading = false
-            Logger.log(.error, category: Logger.auth, message: "회원가입 실패: \(error.localizedDescription)")
-            return false
-        }
-    }
-    
-    /// 닉네임 중복 확인
-    @MainActor
-    func checkNickname(_ nickname: String) async -> (success: Bool, data: Bool) {
-        do {
-            let response = try await UserService.shared.fetchUserNickname(nickname: nickname)
-            return (response.success, response.data.isAvailable)
-        } catch {
-            Logger.log(.error, category: Logger.auth, message: "닉네임 중복 검사 실패: \(error.localizedDescription)")
-            return (false, false)
-        }
-    }
-    
-    /// 이메일 중복 확인
-    @MainActor
-    func checkEmail(_ email: String) async -> (success: Bool, data: Bool) {
-        do {
-            let response = try await UserService.shared.fetchUserEmail(email: email)
-            return (response.success, response.data.isAvailable)
-        } catch {
-            Logger.log(.error, category: Logger.auth, message: "이메일 중복 검사 실패: \(error.localizedDescription)")
-            return (false, false)
         }
     }
     

--- a/CineHive/CineHive/Features/Auth/View/LoginView.swift
+++ b/CineHive/CineHive/Features/Auth/View/LoginView.swift
@@ -49,7 +49,7 @@ struct LoginView: View {
                 
                 Text("이메일로 로그인")
                     .font(.system(size: 16, weight: .semibold))
-                    .frame(width: 320, height: 30, alignment: .leading)
+                    .frame(width: 330, height: 30, alignment: .leading)
                 
                 // 로그인 입력 필드
                 VStack(spacing: 16) {
@@ -94,8 +94,38 @@ struct LoginView: View {
                     Text(errorMessage)
                         .font(.system(size: 14))
                         .foregroundColor(.red)
-                        .frame(width: 320, height: 20, alignment: .leading)
+                        .frame(width: 330, height: 20, alignment: .leading)
                         .padding(.top, 4)
+                }
+                
+                if viewModel.shouldOfferEmailVerificationResend {
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack(alignment: .top, spacing: 8) {
+                            Image(systemName: "envelope.badge")
+                                .imageScale(.medium)
+                            Text("이 계정은 이메일 인증이 필요해요. 메일함에서 인증 링크를 눌러 완료한 뒤 다시 로그인해주세요.")
+                                .font(.system(size: 14))
+                        }
+                        Button {
+                            Task { await viewModel.resendSignupVerification() }
+                        } label: {
+                            Text("인증 메일 재발송")
+                                .font(.system(size: 14, weight: .semibold))
+                                .padding(.leading, 32)
+                        }
+                    }
+                    .padding(12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(Color(uiColor: .systemYellow).opacity(0.15))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(Color(uiColor: .systemYellow).opacity(0.5), lineWidth: 1)
+                    )
+                    .frame(width: 330, alignment: .leading)
+                    .padding(.leading, 5)
+                    .padding(.top, 8)
                 }
                 
                 // 로그인 버튼
@@ -119,7 +149,7 @@ struct LoginView: View {
                     .clipShape(RoundedRectangle(cornerRadius: 12))
                 }
                 .padding(.top, 16)
-                .disabled(viewModel.isLoggingIn)
+                .disabled(viewModel.isLoggingIn || viewModel.email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || viewModel.password.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 
                 HStack {
                     NavigationLink(destination: SignUpView().navigationBarBackButtonHidden(true)) {

--- a/CineHive/CineHive/Features/Auth/View/LoginView.swift
+++ b/CineHive/CineHive/Features/Auth/View/LoginView.swift
@@ -45,11 +45,15 @@ struct LoginView: View {
                             }
                         }
                 }
-                .frame(width: 330, height: 250)
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 20)
+                .frame(height: 250)
                 
                 Text("이메일로 로그인")
                     .font(.system(size: 16, weight: .semibold))
-                    .frame(width: 330, height: 30, alignment: .leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 20)
+                    .frame(height: 30)
                 
                 // 로그인 입력 필드
                 VStack(spacing: 16) {
@@ -87,14 +91,17 @@ struct LoginView: View {
                             .stroke(Color("FontColor"), lineWidth: 0.6)
                     )
                 }
-                .frame(width: 330)
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 20)
                 
                 // 오류 메시지
                 if let errorMessage = viewModel.errorMessage {
                     Text(errorMessage)
                         .font(.system(size: 14))
                         .foregroundColor(.red)
-                        .frame(width: 330, height: 20, alignment: .leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 20)
+                        .frame(height: 20)
                         .padding(.top, 4)
                 }
                 
@@ -123,8 +130,8 @@ struct LoginView: View {
                         RoundedRectangle(cornerRadius: 10)
                             .stroke(Color(uiColor: .systemYellow).opacity(0.5), lineWidth: 1)
                     )
-                    .frame(width: 330, alignment: .leading)
-                    .padding(.leading, 5)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 20)
                     .padding(.top, 8)
                 }
                 
@@ -144,10 +151,12 @@ struct LoginView: View {
                     }
                     .font(.system(size: 18, weight: .bold))
                     .foregroundStyle(.white)
-                    .frame(width: 330, height: 50)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 50)
                     .background(Color("LoginBtnColor"))
                     .clipShape(RoundedRectangle(cornerRadius: 12))
                 }
+                .padding(.horizontal, 20)
                 .padding(.top, 16)
                 .disabled(viewModel.isLoggingIn || viewModel.email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || viewModel.password.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 
@@ -166,7 +175,8 @@ struct LoginView: View {
                             .foregroundStyle(Color("FontColor"))
                     }
                 }
-                .frame(width: 330)
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 20)
                 .padding(.top, 16)
                 
                 Spacer()

--- a/CineHive/CineHive/Features/Auth/View/LoginView.swift
+++ b/CineHive/CineHive/Features/Auth/View/LoginView.swift
@@ -10,6 +10,11 @@ import SwiftUI
 struct LoginView: View {
     @State private var viewModel = LoginViewModel()
     @Environment(\.dismiss) private var dismiss
+    @FocusState private var focusedField: Field?
+    
+    enum Field {
+        case email, password
+    }
     
     var body: some View {
         NavigationStack {
@@ -59,11 +64,12 @@ struct LoginView: View {
                 VStack(spacing: 16) {
                     // 이메일 필드
                     TextField("이메일", text: $viewModel.email)
+                        .focused($focusedField, equals: .email)
                         .padding()
                         .frame(height: 50)
                         .background(
                             RoundedRectangle(cornerRadius: 12)
-                                .stroke(Color("FontColor"), lineWidth: 0.6)
+                                .stroke(focusedField == .email ? Color("LoginBtnColor") : Color("FontColor"), lineWidth: focusedField == .email ? 1.5 : 0.6)
                         )
                         .textInputAutocapitalization(.never)
                         .keyboardType(.emailAddress)
@@ -73,12 +79,19 @@ struct LoginView: View {
                     HStack {
                         if viewModel.showPassword {
                             TextField("비밀번호", text: $viewModel.password)
+                                .focused($focusedField, equals: .password)
                         } else {
                             SecureField("비밀번호", text: $viewModel.password)
+                                .focused($focusedField, equals: .password)
                         }
                         
                         Button(action: {
-                            viewModel.showPassword.toggle()
+                            withAnimation(.easeInOut(duration: 0.15)) {
+                                viewModel.showPassword.toggle()
+                            }
+                            DispatchQueue.main.async {
+                                focusedField = .password
+                            }
                         }, label: {
                             Image(systemName: viewModel.showPassword ? "eye" : "eye.slash")
                                 .foregroundStyle(.gray)
@@ -88,8 +101,11 @@ struct LoginView: View {
                     .frame(height: 50)
                     .background(
                         RoundedRectangle(cornerRadius: 12)
-                            .stroke(Color("FontColor"), lineWidth: 0.6)
+                            .stroke(focusedField == .password ? Color("LoginBtnColor") : Color("FontColor"), lineWidth: focusedField == .password ? 1.5 : 0.6)
                     )
+                    .onChange(of: viewModel.showPassword) { _ in
+                        DispatchQueue.main.async { focusedField = .password }
+                    }
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.horizontal, 20)

--- a/CineHive/CineHive/Features/Auth/View/LoginView.swift
+++ b/CineHive/CineHive/Features/Auth/View/LoginView.swift
@@ -141,7 +141,7 @@ struct LoginView: View {
                 
                 Spacer()
             }
-            .padding(.horizontal)
+            .padding(.horizontal, 16)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {

--- a/CineHive/CineHive/Features/Auth/View/LoginView.swift
+++ b/CineHive/CineHive/Features/Auth/View/LoginView.swift
@@ -31,12 +31,12 @@ struct LoginView: View {
                                 await viewModel.socialLogin(provider: .kakao)
                             }
                         }
-                    NaverLoginBtnView()
-                        .onTapGesture {
-                            Task {
-                                await viewModel.socialLogin(provider: .naver)
-                            }
-                        }
+//                    NaverLoginBtnView()
+//                        .onTapGesture {
+//                            Task {
+//                                await viewModel.socialLogin(provider: .naver)
+//                            }
+//                        }
                     GoogleLoginBtnView()
                         .onTapGesture {
                             Task {

--- a/CineHive/CineHive/Features/Auth/View/LoginView.swift
+++ b/CineHive/CineHive/Features/Auth/View/LoginView.swift
@@ -122,7 +122,7 @@ struct LoginView: View {
                 .disabled(viewModel.isLoggingIn)
                 
                 HStack {
-                    NavigationLink(destination: SignUpView()) {
+                    NavigationLink(destination: SignUpView().navigationBarBackButtonHidden(true)) {
                         Text("회원이 아니신가요?")
                             .font(.system(size: 16, weight: .medium))
                             .foregroundStyle(Color("FontColor"))

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -67,14 +67,15 @@ struct SignUpView: View {
                         focus: $focusedField,
                         field: .email,
                     )
-                    if let emailError = viewModel.emailCheckMessage {
-                        Text(emailError)
-                            .font(.system(size: 14))
-                            .foregroundColor(.red)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.horizontal, 25)
-                            .padding(.top, 10)
-                    }
+                    
+                    Text(viewModel.emailCheckMessage)
+                        .font(.system(size: 14))
+                        .foregroundColor(
+                            !viewModel.emailAvailable ? .red : .green)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 25)
+                        .padding(.top, 10)
+                    
                 case .password:
                     PasswordFieldView(title: "비밀번호를 입력해 주세요.", text: $viewModel.password, showPassword: $viewModel.showPassword, focus: $focusedField, field: .password)
                     VStack(alignment: .leading, spacing: 6) {
@@ -101,14 +102,14 @@ struct SignUpView: View {
                         focus: $focusedField,
                         field: .nickname
                     )
-                    if let nicknameError = viewModel.nicknameCheckMessage {
-                        Text(nicknameError)
-                            .font(.system(size: 14))
-                            .foregroundColor(.red)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.horizontal, 25)
-                            .padding(.top, 10)
-                    }
+                    
+                    Text(viewModel.nicknameCheckMessage)
+                        .font(.system(size: 14))
+                        .foregroundColor(!viewModel.nicknameAvailable ? .red : .green)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 25)
+                        .padding(.top, 10)
+                    
                 }
                 Spacer()
                 // 다음/회원가입 버튼
@@ -119,7 +120,7 @@ struct SignUpView: View {
                             // 버튼 클릭 시 이메일 중복 검사
                             await viewModel.checkEmailWithFormatValidation()
                             await viewModel.checkValidateEmail()
-                            if viewModel.emailCheckMessage == nil {
+                            if viewModel.emailAvailable == true {
                                 step = .password
                             }
                         case .password:

--- a/CineHive/CineHive/Features/Auth/View/SignUpView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SignUpView.swift
@@ -130,7 +130,7 @@ struct SignUpView: View {
                         case .nickname:
                             // 버튼 클릭 시 닉네임 중복 검사
                             await viewModel.checkValidateNickname()
-                            if viewModel.nicknameCheckMessage == nil {
+                            if viewModel.nicknameAvailable {
                                 await viewModel.signUp()
                             }
                         }

--- a/CineHive/CineHive/Features/Auth/View/SocialLogin/GoogleLoginBtnView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SocialLogin/GoogleLoginBtnView.swift
@@ -13,7 +13,9 @@ struct GoogleLoginBtnView: View {
     var body: some View {
         Button(action: {
             if let rootVC = UIApplication.shared.rootViewController() {
-                viewModel.login(presentingViewController: rootVC)
+                Task {
+                    await viewModel.googleSignIn(from: rootVC)
+                }
             }
         }, label: {
             HStack {
@@ -34,3 +36,4 @@ struct GoogleLoginBtnView: View {
         }
     }
 }
+

--- a/CineHive/CineHive/Features/Auth/View/SocialLogin/LoginViewController.swift
+++ b/CineHive/CineHive/Features/Auth/View/SocialLogin/LoginViewController.swift
@@ -1,0 +1,24 @@
+//
+//  LoginViewController.swift
+//  CineHive
+//
+//  Created by 존진 on 10/16/25.
+//
+
+import Foundation
+import UIKit
+
+final class LoginViewController: UIViewController {
+    private let viewModel = GoogleLoginViewModel()
+
+    @IBAction func didTapGoogleLogin(_ sender: UIButton) {
+        Task { @MainActor in
+            await viewModel.googleSignIn(from: self)
+            if viewModel.shouldNavigateToMain {
+                // 메인 화면으로 전환
+            } else if viewModel.toast.isShowing {
+                // 토스트/알럿 표시
+            }
+        }
+    }
+}

--- a/CineHive/CineHive/Features/Auth/View/SocialLogin/NaverLoginBtnView.swift
+++ b/CineHive/CineHive/Features/Auth/View/SocialLogin/NaverLoginBtnView.swift
@@ -22,6 +22,7 @@ struct NaverLoginBtnView: View {
                     .font(.system(size: 15, weight: .bold))
                     .foregroundStyle(.white)
             }
+            .hidden()
             .frame(width: 330, height: 44)
             .background(Color("NaverColor"))
             .clipShape(RoundedRectangle(cornerRadius: 12))

--- a/CineHive/CineHive/Features/Auth/ViewModel/GoogleLoginViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/GoogleLoginViewModel.swift
@@ -8,13 +8,15 @@
 import Foundation
 import GoogleSignIn
 import SwiftUI
+import Supabase
+import UIKit
 
 @Observable
 class GoogleLoginViewModel {
     
     private let userService: UserService
     private let userState: UserState
-    
+
     // 네비게이션 상태
     var shouldNavigateToMain: Bool = false
     var toast: ToastState = ToastState()
@@ -24,92 +26,32 @@ class GoogleLoginViewModel {
         self.userState = userState
     }
     
-    // Google 로그인 플로우를 시작하고 로그인 처리
-    func login(presentingViewController: UIViewController) {
-        guard let clientID = Bundle.main.object(forInfoDictionaryKey: "GIDClientID") as? String else {
-            self.toast = ToastState(isShowing: true, message: "Google Client ID를 불러올 수 없습니다.", type: .error)
-            return
-        }
+    @MainActor
+    func googleSignIn(from presenting: UIViewController) async {
+        do {
+            // 1) Google 네이티브 로그인
+            let result = try await GIDSignIn.sharedInstance.signIn(withPresenting: presenting)
 
-        let scopes = [
-            "https://www.googleapis.com/auth/userinfo.profile",
-            "https://www.googleapis.com/auth/userinfo.email"
-        ]
-
-        let config = GIDConfiguration(clientID: clientID)
-        GIDSignIn.sharedInstance.configuration = config
-
-        GIDSignIn.sharedInstance.signIn(
-            withPresenting: presentingViewController,
-            hint: nil,
-            additionalScopes: scopes
-        ) { [weak self] result, error in
-            guard let self else { return }
-
-            if let error = error {
-                self.toast = ToastState(isShowing: true, message: "Google 로그인 중 오류 발생: \(error.localizedDescription)", type: .error)
+            // 2) 토큰 추출
+            guard let idToken = result.user.idToken?.tokenString else {
+                self.toast = ToastState(isShowing: true, message: "Google ID 토큰을 가져올 수 없습니다.", type: .error)
                 return
             }
+            let accessToken = result.user.accessToken.tokenString
 
-            guard let signInResult = result else {
-                self.toast = ToastState(isShowing: true, message: "Google 로그인 결과가 없습니다.", type: .error)
-                return
-            }
+            // 3) Supabase Auth로 토큰 전달 → 세션 생성
+            try await SupabaseManager.shared.auth.signInWithIdToken(
+                credentials: OpenIDConnectCredentials(
+                    provider: .google,
+                    idToken: idToken,
+                    accessToken: accessToken
+                )
+            )
 
-            self.refreshGoogleTokenAndLogin(signInResult: signInResult)
-        }
-    }
-
-    // 사용자 토큰 새로고침하고 로그인 처리
-    private func refreshGoogleTokenAndLogin(signInResult: GIDSignInResult) {
-        Task { [weak self] in
-            guard let self else { return }
-            
-            var retryCount = 0
-            let maxRetries = 3
-
-            while retryCount < maxRetries {
-                let (fetchedUser, fetchError) = await self.refreshGoogleUser(signInResult.user)
-
-                if let error = fetchError {
-                    retryCount += 1
-                    if retryCount >= maxRetries {
-                        self.toast = ToastState(isShowing: true, message: "Google 토큰 갱신 실패: \(error.localizedDescription)", type: .error)
-                        return
-                    }
-                    continue
-                }
-
-                guard let user = fetchedUser else {
-                    retryCount += 1
-                    if retryCount >= maxRetries {
-                        self.toast = ToastState(isShowing: true, message: "Google 사용자 정보를 가져올 수 없습니다.", type: .error)
-                        return
-                    }
-                    continue
-                }
-
-                let accessToken = user.accessToken.tokenString
-                
-                let result = await self.userState.socialLogin(provider: .google, token: accessToken)
-                switch result {
-                case .successNavigateToMain:
-                    self.shouldNavigateToMain = true
-                case .failure(let message):
-                    self.toast = ToastState(isShowing: true, message: message.message, type: .error)
-                }
-                return
-            }
-
-            self.toast = ToastState(isShowing: true, message: "Google 토큰 갱신이 반복 실패했습니다.", type: .error)
-        }
-    }
-    
-    private func refreshGoogleUser(_ user: GIDGoogleUser) async -> (GIDGoogleUser?, Error?) {
-        await withCheckedContinuation { continuation in
-            user.refreshTokensIfNeeded { refreshedUser, error in
-                continuation.resume(returning: (refreshedUser, error))
-            }
+            // 4) 성공 시 내비게이션 트리거
+            self.shouldNavigateToMain = true
+        } catch {
+            self.toast = ToastState(isShowing: true, message: "Google 로그인 중 오류: \(error.localizedDescription)", type: .error)
         }
     }
 }

--- a/CineHive/CineHive/Features/Auth/ViewModel/KakaoLoginViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/KakaoLoginViewModel.swift
@@ -11,12 +11,14 @@ import OSLog
 import KakaoSDKCommon
 import KakaoSDKAuth
 import KakaoSDKUser
+import Supabase
 
 @Observable
 class KaKaoLoginViewModel {
     
     private let userService: UserService
     private let userState: UserState
+    private let supabase = SupabaseConfig.shared.client
     
     // 네비게이션 상태
     var shouldNavigateToMain: Bool = false
@@ -28,35 +30,17 @@ class KaKaoLoginViewModel {
     }
     
     func login() {
-        let loginHandler: (OAuthToken?, Error?) -> Void = { (oauthToken, error) in
-            if let error = error {
+        Task {
+            do {
+                try await supabase.auth.signInWithOAuth(
+                    provider: .kakao,
+                    redirectTo: URL(string: SupabaseConfig.Auth.appRedirect)
+                )
+                
+            } catch {
                 Logger.log(.error, category: Logger.auth, message: "카카오 로그인 실패: \(error.localizedDescription)")
-                return
+                self.toast = ToastState(isShowing: true, message: "카카오 로그인에 실패했어요. 잠시 후 다시 시도해주세요.", type: .error)
             }
-            
-            guard let token = oauthToken else {
-                Logger.log(.error, category: Logger.auth, message: "OAuth 토큰 없음")
-                return
-            }
-            
-            Task {
-                let result = await self.userState.socialLogin(provider: .kakao, token: token.accessToken)
-                switch result {
-                case .successNavigateToMain:
-                    // MainTabView로 이동 준비
-                    self.shouldNavigateToMain = true
-                case .failure(let message):
-                    self.toast = ToastState(isShowing: true, message: message.message, type: .error)
-                }
-            }
-        }
-        
-        if UserApi.isKakaoTalkLoginAvailable() {
-            // 카카오톡 앱 로그인
-            UserApi.shared.loginWithKakaoTalk(completion: loginHandler)
-        } else {
-            // 카카오톡 웹 로그인
-            UserApi.shared.loginWithKakaoAccount(completion: loginHandler)
         }
     }
 }

--- a/CineHive/CineHive/Features/Auth/ViewModel/KakaoLoginViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/KakaoLoginViewModel.swift
@@ -31,12 +31,16 @@ class KaKaoLoginViewModel {
     
     func login() {
         Task {
+            // 이미 로그인된 세션이 있으면 바로 진행
+            if (try? await supabase.auth.session) != nil {
+                self.shouldNavigateToMain = true
+                return
+            }
             do {
                 try await supabase.auth.signInWithOAuth(
                     provider: .kakao,
                     redirectTo: URL(string: SupabaseConfig.Auth.appRedirect)
                 )
-                
             } catch {
                 Logger.log(.error, category: Logger.auth, message: "카카오 로그인 실패: \(error.localizedDescription)")
                 self.toast = ToastState(isShowing: true, message: "카카오 로그인에 실패했어요. 잠시 후 다시 시도해주세요.", type: .error)

--- a/CineHive/CineHive/Features/Auth/ViewModel/LoginViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/LoginViewModel.swift
@@ -59,16 +59,21 @@ class LoginViewModel {
         } catch {
             let nsError = error as NSError
             let code = nsError.code
-            if code == 400 {
-                let desc = error.localizedDescription.lowercased()
-                if desc.contains("email not confirmed") || desc.contains("email_not_confirmed") {
-                    errorMessage = "이메일 인증이 필요해요. 메일함에서 인증을 완료한 뒤 다시 로그인해주세요."
-                    shouldOfferEmailVerificationResend = true
-                } else {
-                    errorMessage = "이메일 또는 비밀번호를 다시 확인해주세요."
-                }
+            let raw = String(describing: error).lowercased()
+            if raw.contains("email_not_confirmed") || raw.contains("email not confirmed") {
+                shouldOfferEmailVerificationResend = true
+            } else if code == 429 {
+                errorMessage = "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."
+                shouldOfferEmailVerificationResend = false
+            } else if code == -1009 {
+                errorMessage = "네트워크 연결을 확인해주세요."
+                shouldOfferEmailVerificationResend = false
+            } else if code == 400 {
+                errorMessage = "이메일 또는 비밀번호를 다시 확인해주세요."
+                shouldOfferEmailVerificationResend = false
             } else {
                 errorMessage = "로그인 중 오류가 발생했습니다. 다시 시도해주세요."
+                shouldOfferEmailVerificationResend = false
             }
         }
     }

--- a/CineHive/CineHive/Features/Auth/ViewModel/LoginViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/LoginViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Supabase
 
 @Observable
 class LoginViewModel {
@@ -18,6 +19,7 @@ class LoginViewModel {
     var isLoggingIn: Bool = false
     var navigateToHome: Bool = false
     var errorMessage: String? = nil
+    var shouldOfferEmailVerificationResend: Bool = false
     
     // 이메일 유효성 검사기
     private let emailValidator: (String) -> Bool = { email in
@@ -28,34 +30,46 @@ class LoginViewModel {
     // 로그인
     @MainActor
     func login() async {
+        let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedPassword = password.trimmingCharacters(in: .whitespacesAndNewlines)
+        
         // 입력 유효성 검사
-        guard !email.isEmpty else {
+        guard !trimmedEmail.isEmpty else {
             errorMessage = "이메일을 입력해주세요."
             return
         }
         
-        guard !password.isEmpty else {
+        guard !trimmedPassword.isEmpty else {
             errorMessage = "비밀번호를 입력해주세요."
             return
         }
         
-        if !emailValidator(email) {
+        if !emailValidator(trimmedEmail) {
             errorMessage = "올바른 이메일 형식이 아닙니다."
             return
         }
         
         isLoggingIn = true
+        defer { isLoggingIn = false }
         errorMessage = nil
         
-        // UserState를 통한 로그인 처리
-        let success = await UserState.shared.login(email: email, password: password)
-        
-        isLoggingIn = false
-        
-        if success {
+        do {
+            _ = try await SupabaseConfig.shared.client.auth.signIn(email: trimmedEmail, password: trimmedPassword)
             navigateToHome = true
-        } else {
-            errorMessage = UserState.shared.errorMessage ?? "로그인에 실패했습니다."
+        } catch {
+            let nsError = error as NSError
+            let code = nsError.code
+            if code == 400 {
+                let desc = error.localizedDescription.lowercased()
+                if desc.contains("email not confirmed") || desc.contains("email_not_confirmed") {
+                    errorMessage = "이메일 인증이 필요해요. 메일함에서 인증을 완료한 뒤 다시 로그인해주세요."
+                    shouldOfferEmailVerificationResend = true
+                } else {
+                    errorMessage = "이메일 또는 비밀번호를 다시 확인해주세요."
+                }
+            } else {
+                errorMessage = "로그인 중 오류가 발생했습니다. 다시 시도해주세요."
+            }
         }
     }
     

--- a/CineHive/CineHive/Features/Auth/ViewModel/LoginViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/LoginViewModel.swift
@@ -78,6 +78,32 @@ class LoginViewModel {
         }
     }
     
+    @MainActor
+    func resendSignupVerification() async {
+        let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedEmail.isEmpty else {
+            errorMessage = "이메일을 입력한 뒤 다시 시도해주세요."
+            return
+        }
+        guard emailValidator(trimmedEmail) else {
+            errorMessage = "올바른 이메일 형식이 아니에요."
+            return
+        }
+        isLoggingIn = true
+        defer { isLoggingIn = false }
+        errorMessage = nil
+        do {
+            try await SupabaseConfig.shared.client.auth.resend(
+                email: trimmedEmail,
+                type: .signup,
+                emailRedirectTo: nil
+            )
+            shouldOfferEmailVerificationResend = false
+        } catch {
+            errorMessage = "인증 메일 재발송 중 오류가 발생했어요. 잠시 후 다시 시도해주세요."
+        }
+    }
+    
     // 소셜 로그인
     @MainActor
     func socialLogin(provider: SocialLoginProvider) async {

--- a/CineHive/CineHive/Features/Auth/ViewModel/NaverLoginViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/NaverLoginViewModel.swift
@@ -9,6 +9,9 @@ import Foundation
 import NaverThirdPartyLogin
 import OSLog
 
+/// NOTE:
+/// 네이버 로그인을 Supabase 백엔드에서 지원하지 않아 앱 정책으로 기능을 비활성화했습니다.
+/// - 남겨둔 ViewModel은 빌드 에러 방지용이며, 호출 시 토스트만 노출하고 바로 반환합니다.
 @Observable
 class NaverLoginViewModel: NSObject, UIApplicationDelegate, NaverThirdPartyLoginConnectionDelegate {
     private let userService: UserService
@@ -24,12 +27,14 @@ class NaverLoginViewModel: NSObject, UIApplicationDelegate, NaverThirdPartyLogin
     
     //MARK: - 로그인 시도
     func login() {
-        NaverThirdPartyLoginConnection.getSharedInstance().delegate = self
-        // 앱을 통한 로그인 & 브라우저를 통한 로그인이 모두 가능
-        NaverThirdPartyLoginConnection
-            .getSharedInstance()
-            .requestThirdPartyLogin()
-        
+        // Naver login is intentionally disabled (Supabase 미지원 정책)
+        self.toast = ToastState(
+            isShowing: true,
+            message: "네이버 로그인은 더 이상 지원하지 않습니다.",
+            type: .warning
+        )
+        Logger.log(.info, category: Logger.auth, message: "Naver login blocked by policy (Supabase unsupported)")
+        return
     }
     
     //MARK: - 토큰 발급 성공

--- a/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
@@ -125,30 +125,17 @@ class SignUpViewModel {
         generalErrorMessage = nil
         
         do {
-            let client = SupabaseConfig.shared.client
-            
-            let metadata: [String: AnyJSON] = [
-                "nickname": .string(nickname)
-            ]
-            
-            // Supabase Auth 회원가입
-            let authResponse = try await client.auth.signUp(
+            let request = AuthSignUpRequest(
                 email: email,
                 password: password,
-                data: metadata
+                nickname: nickname
             )
             
-            // 세션 O -> Supabase trigger에서 프로필 생성 처리
-            if let session = authResponse.session {
-                // 프로필 생성은 Supabase 트리거에서 처리
-            }
-            // 세션 X -> 이메일 인증 필요
-            else if authResponse.user != nil {
-                isSignUpSuccess = true
-                // 프로필 생성은 이메일 인증 후 로그인 시점에 진행
-            } else {
-                throw NSError(domain: "SignUp", code: -2, userInfo: [NSLocalizedDescriptionKey: "회원가입 응답에 세션/사용자 정보가 없습니다."])
-            }
+            // Supabase Auth 회원가입
+            try await UserService.shared.registerUser(user: request)
+            
+            isSignUpSuccess = true
+            
         } catch {
             let msg = error.localizedDescription.lowercased()
             if msg.contains("already registered") || msg.contains("already exists") || msg.contains("user exists") {

--- a/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
@@ -105,10 +105,10 @@ class SignUpViewModel {
             let available = try await UserService.shared.fetchUserNickname(nickname: trimmed)
             
             if available {
-                self.nicknameCheckMessage = "사용 가능한 이메일이에요."
+                self.nicknameCheckMessage = "사용 가능한 닉네임이에요."
                 self.nicknameAvailable = true
             } else {
-                self.nicknameCheckMessage = "이미 사용 중인 이메일이에요."
+                self.nicknameCheckMessage = "이미 사용 중인 닉네임이에요."
                 self.nicknameAvailable = false
             }
 

--- a/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
+++ b/CineHive/CineHive/Features/Auth/ViewModel/SignUpViewModel.swift
@@ -46,9 +46,9 @@ class SignUpViewModel {
     // 상태 및 오류 메시지
     var emailFormatInvalidMessage: String? = nil
     var nicknameAvailable: Bool = false
-    var nicknameCheckMessage: String? = nil
+    var nicknameCheckMessage: String = ""
     var emailAvailable: Bool = false
-    var emailCheckMessage: String? = nil
+    var emailCheckMessage: String = ""
     var isSignUpSuccess: Bool = false
     var isSigningUp: Bool = false
     var generalErrorMessage: String? = nil
@@ -80,31 +80,17 @@ class SignUpViewModel {
         let trimmed = email.trimmingCharacters(in: .whitespacesAndNewlines)
         
         do {
-            let client = SupabaseConfig.shared.client
-            let params: [String: AnyJSON] = [
-                "p_email": .string(trimmed)
-            ]
-            let response = try await client
-                .rpc("check_email_available", params: params)
-                .execute()
+            let available = try await UserService.shared.fetchUserEmail(email: trimmed)
             
-            let data = response.data
-            guard !data.isEmpty else {
+            if available {
+                self.emailCheckMessage = "사용 가능한 이메일이에요."
+                self.emailAvailable = true
+            } else {
+                self.emailCheckMessage = "이미 사용 중인 이메일이에요."
                 self.emailAvailable = false
-                self.emailCheckMessage = "이메일 확인 실패: 빈 응답"
-                return
             }
-            
-            if let available = try? JSONDecoder().decode(Bool.self, from: data) {
-                self.emailAvailable = available
-                self.emailCheckMessage = available ? nil : "이미 사용 중인 이메일이에요."
-                return
-            }
-            
-            self.emailAvailable = false
-            self.emailCheckMessage = "이메일 확인 실패: 응답 형식 오류"
+
         } catch {
-            self.emailAvailable = false
             self.emailCheckMessage = "이메일 확인 실패: \(error.localizedDescription)"
         }
     }
@@ -116,34 +102,17 @@ class SignUpViewModel {
         let trimmed = nickname.trimmingCharacters(in: .whitespacesAndNewlines)
         
         do {
-            let client = SupabaseConfig.shared.client
-            // 파라미터 타입을 명시적으로 AnyJSON으로 지정
-            let params: [String: AnyJSON] = [
-                "p_nickname": .string(trimmed)
-            ]
-            let response = try await client
-                .rpc("check_nickname_available", params: params)
-                .execute()
+            let available = try await UserService.shared.fetchUserNickname(nickname: trimmed)
             
-            let data = response.data
-            guard !data.isEmpty else {
+            if available {
+                self.nicknameCheckMessage = "사용 가능한 이메일이에요."
+                self.nicknameAvailable = true
+            } else {
+                self.nicknameCheckMessage = "이미 사용 중인 이메일이에요."
                 self.nicknameAvailable = false
-                self.nicknameCheckMessage = "닉네임 확인 실패: 빈 응답"
-                return
             }
-            
-            // 단일 Bool (true/false)
-            if let available = try? JSONDecoder().decode(Bool.self, from: data) {
-                self.nicknameAvailable = available
-                self.nicknameCheckMessage = available ? nil : "이미 사용 중인 닉네임이에요."
-                return
-            }
-            
-            // 파싱 실패
-            self.nicknameAvailable = false
-            self.nicknameCheckMessage = "닉네임 확인 실패: 응답 형식 오류"
+
         } catch {
-            self.nicknameAvailable = false
             self.nicknameCheckMessage = "닉네임 확인 실패: \(error.localizedDescription)"
         }
     }

--- a/CineHive/CineHive/Features/Home/View/HomeHeaderView.swift
+++ b/CineHive/CineHive/Features/Home/View/HomeHeaderView.swift
@@ -12,6 +12,7 @@ struct HomeHeaderView: View {
     @Binding var isSearchActive: Bool
     @Binding var showProfileOptions: Bool
     var onProfileTap: (() -> Void)? = nil
+    var avatarURL: String? = nil
     
     var body: some View {
         HStack(spacing: 15) {
@@ -36,33 +37,65 @@ struct HomeHeaderView: View {
             .buttonStyle(ScaleButtonStyle())
             .accessibilityLabel("검색")
             
-            ProfileButtonView {
+            Button {
                 withAnimation(.spring(duration: 0.3)) {
                     if let customAction = onProfileTap {
                         customAction()
                     } else {
-                        handleProfileTap()
+                        // 기본: 프로필 옵션 표시
+                        showProfileOptions.toggle()
                     }
                 }
+            } label: {
+                if let raw = avatarURL {
+                    let cleaned = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+                    let https = cleaned.hasPrefix("http://") ? cleaned.replacingOccurrences(of: "http://", with: "https://") : cleaned
+                    if let url = URL(string: https) {
+                        AsyncImage(url: url) { phase in
+                            switch phase {
+                            case .empty:
+                                Circle().fill(Color.gray.opacity(0.2))
+                            case .success(let image):
+                                image.resizable().scaledToFill()
+                            case .failure:
+                                Image(systemName: "person.crop.circle.fill")
+                                    .resizable().scaledToFill()
+                            @unknown default:
+                                Image(systemName: "person.crop.circle")
+                                    .resizable().scaledToFill()
+                            }
+                        }
+                        .frame(width: 28, height: 28)
+                        .clipShape(Circle())
+                    } else {
+                        // URL 변환 실패 시 기본 아이콘
+                        Image(systemName: "person.crop.circle.fill")
+                            .resizable().scaledToFill()
+                            .frame(width: 28, height: 28)
+                            .foregroundStyle(CHColors.textColor)
+                    }
+                } else {
+                    // 로그인 칩 (기존 스타일)
+                    Text("로그인")
+                        .font(.system(size: 12, weight: .semibold))
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(
+                            Capsule()
+                                .fill(Color.black.opacity(0.25))
+                        )
+                        .overlay(
+                            Capsule()
+                                .strokeBorder(Color.white.opacity(0.3), lineWidth: 0.5)
+                        )
+                        .foregroundStyle(.white)
+                }
             }
+            .buttonStyle(ScaleButtonStyle())
+            .accessibilityLabel("프로필")
         }
         .padding(.horizontal, 15)
         .padding(.vertical, 10)
-    }
-    
-    // 프로필 버튼 탭 처리
-    private func handleProfileTap() {
-        if userState.isLoggedIn || userState.isGuestMode {
-            // 이미 로그인한 상태 - 프로필 옵션 표시
-            showProfileOptions.toggle()
-        } else {
-            // 로그인 필요 상태 - 로그인 화면 또는 프로필 탭으로 이동
-            showProfileOptions.toggle() // 임시로 동일한 동작 수행
-            
-            // 로그인이 필요함을 알리는 방법은 앱 구조에 따라 달라질 수 있음
-            // 예: 탭 바 컨트롤러의 프로필 탭으로 이동
-            // 또는 로그인 모달 표시 등
-        }
     }
 }
 

--- a/CineHive/CineHive/Features/Home/View/HomeTabView.swift
+++ b/CineHive/CineHive/Features/Home/View/HomeTabView.swift
@@ -11,6 +11,7 @@ struct HomeTabView: View {
     // 환경과 뷰모델
     @Environment(UserState.self) private var userState
     @State private var viewModel = HomeViewModel()
+    @State private var profileModel = ProfileViewModel()
     
     var body: some View {
         ZStack {
@@ -21,8 +22,8 @@ struct HomeTabView: View {
                 HomeHeaderView(
                     isSearchActive: $viewModel.isSearchActive,
                     showProfileOptions: $viewModel.showProfileOptions,
-                    onProfileTap: viewModel.handleProfileTap,
-                    avatarURL: viewModel.profileImageURLString
+                    onProfileTap: profileModel.handleProfileTap,
+                    avatarURL: profileModel.profileImageURLString
                 )
                 
                 // 메인 콘텐츠

--- a/CineHive/CineHive/Features/Home/View/HomeTabView.swift
+++ b/CineHive/CineHive/Features/Home/View/HomeTabView.swift
@@ -21,7 +21,8 @@ struct HomeTabView: View {
                 HomeHeaderView(
                     isSearchActive: $viewModel.isSearchActive,
                     showProfileOptions: $viewModel.showProfileOptions,
-                    onProfileTap: viewModel.handleProfileTap
+                    onProfileTap: viewModel.handleProfileTap,
+                    avatarURL: viewModel.profileImageURLString
                 )
                 
                 // 메인 콘텐츠

--- a/CineHive/CineHive/Features/Home/ViewModel/HomeViewModel.swift
+++ b/CineHive/CineHive/Features/Home/ViewModel/HomeViewModel.swift
@@ -44,21 +44,6 @@ final class HomeViewModel {
     init(movieService: MovieService = .shared, userState: UserState = .shared) {
         self.movieService = movieService
         self.userState = userState
-        // Kakao/Supabase 인증 상태 변화 구독 및 초기 프로필 로드
-        Task {
-            let auth = SupabaseConfig.shared.client.auth
-            if (try? await auth.session) != nil {
-                await self.loadProfileFromSupabase()
-            }
-            for await change in auth.authStateChanges {
-                switch change.event {
-                case .signedIn, .tokenRefreshed, .userUpdated, .initialSession:
-                    await self.loadProfileFromSupabase()
-                default:
-                    break
-                }
-            }
-        }
     }
     
     // MARK: - 데이터 로딩 메소드
@@ -132,97 +117,7 @@ final class HomeViewModel {
         isLoading = false
     }
     
-    // MARK: - 프로필 로딩
-    @MainActor
-    func loadProfileFromSupabase() async {
-        guard let session = try? await SupabaseConfig.shared.client.auth.session else {
-            return
-        }
-        let user = session.user
-        var nameCandidate: String?
-        var imageCandidate: String?
-        let nameKeys = ["nickname", "preferred_username", "full_name", "name", "user_name"]
-        let imageKeys = ["avatar_url", "profile_image_url", "picture", "thumbnail_image_url"]
-
-        if let meta = user.userMetadata as? [String: Any] {
-            for k in nameKeys {
-                if let v = coerceString(meta[k]), !v.isEmpty { nameCandidate = v; break }
-            }
-            for k in imageKeys {
-                if let v = coerceString(meta[k]), !v.isEmpty { imageCandidate = v; break }
-            }
-        }
-
-        if (nameCandidate == nil || imageCandidate == nil), let identities = user.identities {
-            if let kakao = identities.first(where: { $0.provider == "kakao" }) {
-                if let data = kakao.identityData as? [String: Any] {
-                    if nameCandidate == nil {
-                        for k in nameKeys {
-                            if let v = coerceString(data[k]), !v.isEmpty { nameCandidate = v; break }
-                        }
-                    }
-                    if imageCandidate == nil {
-                        for k in imageKeys {
-                            if let v = coerceString(data[k]), !v.isEmpty { imageCandidate = v; break }
-                        }
-                    }
-                    if imageCandidate == nil {
-                        let desc = String(describing: data)
-                        if let url = extractFirstImageURL(in: desc) { imageCandidate = url }
-                    }
-                }
-            }
-        }
-
-        if let img = imageCandidate, img.hasPrefix("http://") {
-            imageCandidate = img.replacingOccurrences(of: "http://", with: "https://")
-        }
-
-        self.profileName = nameCandidate ?? (user.email ?? "")
-        self.profileImageURLString = imageCandidate
-    }
-
-    // MARK: - Helpers (Profile)
-    private func coerceString(_ value: Any?) -> String? {
-        guard let value = value else { return nil }
-        if let s = value as? String { return s }
-        if let u = value as? URL { return u.absoluteString }
-        if let n = value as? NSNumber { return n.stringValue }
-        let s = String(describing: value)
-        return s.isEmpty ? nil : s
-    }
-
-    private func extractFirstImageURL(in text: String) -> String? {
-        let pattern = #"https?:\/\/[\w\-\.]*kakaocdn\.net[^\s\"]+|https?:\/\/[^\s\"]+\.(?:jpg|jpeg|png)"#
-        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { return nil }
-        let range = NSRange(text.startIndex..<text.endIndex, in: text)
-        if let match = regex.firstMatch(in: text, options: [], range: range), let r = Range(match.range, in: text) {
-            return String(text[r])
-        }
-        return nil
-    }
-
     // MARK: - 프로필 관련 메소드
-    
-    // 프로필 버튼 탭 핸들러
-    func handleProfileTap() {
-        if userState.isLoggedIn || userState.isGuestMode {
-            // 프로필 옵션 시트 표시
-            showProfileOptions = true
-        } else {
-            // 로그인 필요 - 사용자에게 알림
-            showNotificationWithMessage("로그인이 필요합니다")
-            
-            // 실제 앱에서는 여기서 로그인 화면으로 이동하거나
-            // 탭바의 프로필 탭으로 이동할 수 있음
-            showProfileOptions = true // 임시로 프로필 옵션 표시
-        }
-    }
-    
-    // 프로필 옵션 토글
-    func toggleProfileOptions() {
-        showProfileOptions.toggle()
-    }
     
     // 검색 활성화 토글
     func toggleSearchActive() {

--- a/CineHive/CineHive/Features/Home/ViewModel/HomeViewModel.swift
+++ b/CineHive/CineHive/Features/Home/ViewModel/HomeViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Observation
 import SwiftUI
+import Supabase
 
 @Observable
 final class HomeViewModel {
@@ -31,6 +32,10 @@ final class HomeViewModel {
     var isSearchActive = false
     var searchText = ""
     var showErrorToast = false
+
+    // 프로필 표시용 상태
+    var profileName: String = ""
+    var profileImageURLString: String?
     
     // 서비스
     private let movieService: MovieService
@@ -39,6 +44,21 @@ final class HomeViewModel {
     init(movieService: MovieService = .shared, userState: UserState = .shared) {
         self.movieService = movieService
         self.userState = userState
+        // Kakao/Supabase 인증 상태 변화 구독 및 초기 프로필 로드
+        Task {
+            let auth = SupabaseConfig.shared.client.auth
+            if (try? await auth.session) != nil {
+                await self.loadProfileFromSupabase()
+            }
+            for await change in auth.authStateChanges {
+                switch change.event {
+                case .signedIn, .tokenRefreshed, .userUpdated, .initialSession:
+                    await self.loadProfileFromSupabase()
+                default:
+                    break
+                }
+            }
+        }
     }
     
     // MARK: - 데이터 로딩 메소드
@@ -112,6 +132,76 @@ final class HomeViewModel {
         isLoading = false
     }
     
+    // MARK: - 프로필 로딩
+    @MainActor
+    func loadProfileFromSupabase() async {
+        guard let session = try? await SupabaseConfig.shared.client.auth.session else {
+            return
+        }
+        let user = session.user
+        var nameCandidate: String?
+        var imageCandidate: String?
+        let nameKeys = ["nickname", "preferred_username", "full_name", "name", "user_name"]
+        let imageKeys = ["avatar_url", "profile_image_url", "picture", "thumbnail_image_url"]
+
+        if let meta = user.userMetadata as? [String: Any] {
+            for k in nameKeys {
+                if let v = coerceString(meta[k]), !v.isEmpty { nameCandidate = v; break }
+            }
+            for k in imageKeys {
+                if let v = coerceString(meta[k]), !v.isEmpty { imageCandidate = v; break }
+            }
+        }
+
+        if (nameCandidate == nil || imageCandidate == nil), let identities = user.identities {
+            if let kakao = identities.first(where: { $0.provider == "kakao" }) {
+                if let data = kakao.identityData as? [String: Any] {
+                    if nameCandidate == nil {
+                        for k in nameKeys {
+                            if let v = coerceString(data[k]), !v.isEmpty { nameCandidate = v; break }
+                        }
+                    }
+                    if imageCandidate == nil {
+                        for k in imageKeys {
+                            if let v = coerceString(data[k]), !v.isEmpty { imageCandidate = v; break }
+                        }
+                    }
+                    if imageCandidate == nil {
+                        let desc = String(describing: data)
+                        if let url = extractFirstImageURL(in: desc) { imageCandidate = url }
+                    }
+                }
+            }
+        }
+
+        if let img = imageCandidate, img.hasPrefix("http://") {
+            imageCandidate = img.replacingOccurrences(of: "http://", with: "https://")
+        }
+
+        self.profileName = nameCandidate ?? (user.email ?? "")
+        self.profileImageURLString = imageCandidate
+    }
+
+    // MARK: - Helpers (Profile)
+    private func coerceString(_ value: Any?) -> String? {
+        guard let value = value else { return nil }
+        if let s = value as? String { return s }
+        if let u = value as? URL { return u.absoluteString }
+        if let n = value as? NSNumber { return n.stringValue }
+        let s = String(describing: value)
+        return s.isEmpty ? nil : s
+    }
+
+    private func extractFirstImageURL(in text: String) -> String? {
+        let pattern = #"https?:\/\/[\w\-\.]*kakaocdn\.net[^\s\"]+|https?:\/\/[^\s\"]+\.(?:jpg|jpeg|png)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { return nil }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        if let match = regex.firstMatch(in: text, options: [], range: range), let r = Range(match.range, in: text) {
+            return String(text[r])
+        }
+        return nil
+    }
+
     // MARK: - 프로필 관련 메소드
     
     // 프로필 버튼 탭 핸들러

--- a/CineHive/CineHive/Features/Home/ViewModel/MovieViewModel.swift
+++ b/CineHive/CineHive/Features/Home/ViewModel/MovieViewModel.swift
@@ -121,18 +121,18 @@ final class MovieViewModel {
         }
     }
     
-    // 사용자 관련 기능
-    func login(email: String, password: String) async -> Bool {
-        do {
-            let loginData = LoginUser(email: email, password: password)
-            let response: LoginResponse = try await UserService.shared.loginUser(user: loginData)
-            isLoggedIn = true
-            currentUser = response.user
-            return true
-        } catch {
-            return false
-        }
-    }
+//    // 사용자 관련 기능
+//    func login(email: String, password: String) async -> Bool {
+//        do {
+//            let loginData = LoginUser(email: email, password: password)
+//            let response: LoginResponse = try await UserService.shared.loginUser(user: loginData)
+//            isLoggedIn = true
+//            currentUser = response.user
+//            return true
+//        } catch {
+//            return false
+//        }
+//    }
     
     func logout() {
         isLoggedIn = false

--- a/CineHive/CineHive/Features/Home/ViewModel/ProfileViewModel.swift
+++ b/CineHive/CineHive/Features/Home/ViewModel/ProfileViewModel.swift
@@ -1,0 +1,148 @@
+//
+//  ProfileViewModel.swift
+//  CineHive
+//
+//  Created by 존진 on 10/14/25.
+//
+
+import Foundation
+import SwiftUI
+import Supabase
+
+@Observable
+final class ProfileViewModel {
+    // MARK: - 상태
+    var showProfileOptions = false
+    var showErrorToast = false
+    var showNotification = false
+    var notificationMessage = ""
+    var profileName: String = ""
+    var profileImageURLString: String?
+    
+    // MARK: - 종속성
+    private let userState: UserState
+    
+    init(userState: UserState = .shared) {
+        self.userState = userState
+        
+        // 자동 프로필 동기화: 앱 시작/로그인/토큰 갱신 시
+        Task {
+            let auth = SupabaseConfig.shared.client.auth
+            // 초기 세션이 있으면 곧바로 로드
+            if (try? await auth.session) != nil {
+                await self.loadProfileFromSupabase()
+            }
+            for await change in auth.authStateChanges {
+                switch change.event {
+                case .signedIn, .tokenRefreshed, .userUpdated, .initialSession:
+                    await self.loadProfileFromSupabase()
+                default:
+                    break
+                }
+            }
+        }
+    }
+    
+    // MARK: - 프로필 액션
+    func handleProfileTap() {
+        if userState.isLoggedIn || userState.isGuestMode {
+            showProfileOptions = true
+        } else {
+            showNotificationWithMessage("로그인이 필요합니다")
+            showProfileOptions = true // 임시 표시
+        }
+    }
+    
+    func toggleProfileOptions() {
+        showProfileOptions.toggle()
+    }
+    
+    @MainActor
+    func handleLogout() {
+        Task {
+            userState.logout()
+            showProfileOptions = false
+            showNotificationWithMessage("로그아웃 되었습니다")
+        }
+    }
+    
+    // MARK: - 알림 제어
+    func dismissNotification() {
+        showNotification = false
+    }
+    
+    func showNotificationWithMessage(_ message: String) {
+        notificationMessage = message
+        showNotification = true
+    }
+    
+    // MARK: - 프로필 로딩
+    @MainActor
+    func loadProfileFromSupabase() async {
+        guard let session = try? await SupabaseConfig.shared.client.auth.session else {
+            return
+        }
+        let user = session.user
+        var nameCandidate: String?
+        var imageCandidate: String?
+        let nameKeys = ["nickname", "preferred_username", "full_name", "name", "user_name"]
+        let imageKeys = ["avatar_url", "profile_image_url", "picture", "thumbnail_image_url"]
+        
+        if let meta = user.userMetadata as? [String: Any] {
+            for k in nameKeys {
+                if let v = coerceString(meta[k]), !v.isEmpty { nameCandidate = v; break }
+            }
+            for k in imageKeys {
+                if let v = coerceString(meta[k]), !v.isEmpty { imageCandidate = v; break }
+            }
+        }
+        
+        if (nameCandidate == nil || imageCandidate == nil), let identities = user.identities {
+            if let kakao = identities.first(where: { $0.provider == "kakao" }) {
+                if let data = kakao.identityData {
+                    if nameCandidate == nil {
+                        for k in nameKeys {
+                            if let v = coerceString(data[k]), !v.isEmpty { nameCandidate = v; break }
+                        }
+                    }
+                    if imageCandidate == nil {
+                        for k in imageKeys {
+                            if let v = coerceString(data[k]), !v.isEmpty { imageCandidate = v; break }
+                        }
+                    }
+                    if imageCandidate == nil {
+                        let desc = String(describing: data)
+                        if let url = extractFirstImageURL(in: desc) { imageCandidate = url }
+                    }
+                }
+            }
+        }
+        
+        if let img = imageCandidate, img.hasPrefix("http://") {
+            imageCandidate = img.replacingOccurrences(of: "http://", with: "https://")
+        }
+        
+        self.profileName = nameCandidate ?? (user.email ?? "")
+        self.profileImageURLString = imageCandidate
+    }
+    
+    // MARK: - Helpers (Profile)
+    private func coerceString(_ value: Any?) -> String? {
+        guard let value = value else { return nil }
+        if let s = value as? String { return s }
+        if let u = value as? URL { return u.absoluteString }
+        if let n = value as? NSNumber { return n.stringValue }
+        let s = String(describing: value)
+        return s.isEmpty ? nil : s
+    }
+    
+    private func extractFirstImageURL(in text: String) -> String? {
+        let pattern = #"https?:\/\/[\w\-\.]*kakaocdn\.net[^\s\"]+|https?:\/\/[^\s\"]+\.(?:jpg|jpeg|png)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { return nil }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        if let match = regex.firstMatch(in: text, options: [], range: range), let r = Range(match.range, in: text) {
+            return String(text[r])
+        }
+        return nil
+    }
+}

--- a/CineHive/CineHive/Services/UserService.swift
+++ b/CineHive/CineHive/Services/UserService.swift
@@ -18,7 +18,7 @@ final class UserService {
 
     /// 회원가입 요청
     func registerUser(user: AuthSignUpRequest) async throws {
-        try await auth.signUp(email: user.email, password: user.password)
+        try await SupabaseManager.shared.auth.signUp(email: user.email, password: user.password, data: user.data)
     }
     
     /// 닉네임 중복 확인

--- a/CineHive/CineHive/Services/UserService.swift
+++ b/CineHive/CineHive/Services/UserService.swift
@@ -6,35 +6,40 @@
 //
 
 import Foundation
+import Supabase
 
 final class UserService {
     static let shared = UserService()
     private init() {}
     
+    private let auth = SupabaseManager.shared.auth
+    
     // MARK: - 인증 없는 요청 (로그인 전)
 
     /// 회원가입 요청
-    func registerUser(user: AuthSignUpRequest) async throws -> SignUpResponse {
-        let endpoint = EndPoint.Auth.register
-        return try await NetworkManager.shared.post(endpoint: endpoint, body: user)
+    func registerUser(user: AuthSignUpRequest) async throws {
+        try await auth.signUp(email: user.email, password: user.password)
     }
     
     /// 닉네임 중복 확인
-    func fetchUserNickname(nickname: String) async throws -> AvailabilityResponse {
-        let endpoint = EndPoint.Auth.checkNickname(nickname)
-        return try await NetworkManager.shared.fetch(endpoint: endpoint)
+    func fetchUserNickname(nickname: String) async throws -> Bool {
+        let params: [String: AnyJSON] = ["p_nickname": .string(nickname)]
+        let available = try await SupabaseManager.shared.callRPCBool("check_nickname_available", params: params)
+        // true = 사용 가능, false = 중복
+        return available
     }
     
     /// 이메일 중복 확인
-    func fetchUserEmail(email: String) async throws -> AvailabilityResponse {
-        let endpoint = EndPoint.Auth.checkEmail(email)
-        return try await NetworkManager.shared.fetch(endpoint: endpoint)
+    func fetchUserEmail(email: String) async throws -> Bool {
+        let params: [String: AnyJSON] = ["p_email": .string(email)]
+        let available = try await SupabaseManager.shared.callRPCBool("check_email_available", params: params)
+        // true = 사용 가능, false = 중복
+        return available
     }
     
     /// 로그인 요청
-    func loginUser(user: LoginUser) async throws -> LoginResponse {
-        let endpoint = EndPoint.Auth.login
-        return try await NetworkManager.shared.post(endpoint: endpoint, body: user)
+    func loginUser(user: AuthSignUpRequest) async throws {
+        try await auth.signIn(email: user.email, password: user.password)
     }
     
     // MARK: - 인증이 필요한 요청 (로그인 후)


### PR DESCRIPTION
## 작업한 내용
- Supabase 연동 구조 개선
    - SupabaseManager 유틸 추가 및 구조 개선
       - Supabase 관련 네트워크 호출 로직을 별도 SupabaseManager로 분리 
    - UserService 로직 분리 및 리팩토링
    - 공용 RPC 호출 구조 정리 및 decode<T> 처리 방식 개선
- ViewModel 정리 및 네이밍 통일
    - LoginViewModel, SignUpViewModel 내부 Auth 호출 방식 수정
    - AuthSignUpRequest DTO 구조 개선([String: AnyJSON]으로 변경)
- OAuth 기반 로그인 로직 개선
    - Naver -> Supabase 미지원으로 인한 뷰 비활성화
    - Kakao, Google -> Supabase OAuth 전환
    - Apple 로그인(Signing & Capabilities 설정 반영)

## PR Point
- Auth 로직 리팩터링 일환으로 정리
- 향후 대응 가능 구조 유지
   → 비활성화 시에도 버튼/함수 구조를 유지하여, 지원 추가 시 손쉽게 복원 가능

### 추후 작업할 내용 (미완성 부분)
<!-- 이슈 번호와 함께 향후 작업 예정인 내용을 작성해주세요 -->
<!-- 연결된 이슈가 있다면 작성해주세요 (예: #123) -->
<!-- 체크리스트 작성 (예: - [ ]) -->
- Apple 로그인 추후 작업 예정
